### PR TITLE
Remove httpmock dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: go
 sudo: false
 
 go:
-  - "1.6"
   - "1.7"
   - "1.8"
   - "1.9"

--- a/golack.go
+++ b/golack.go
@@ -61,12 +61,12 @@ func New(config *Config, options ...Option) *Golack {
 
 func (g *Golack) StartRTMSession(ctx context.Context) (*webapi.RTMStart, error) {
 	rtmStart := &webapi.RTMStart{}
-	if err := g.webClient.Get(ctx, "rtm.start", nil, &rtmStart); err != nil {
+	if err := g.webClient.Get(ctx, "rtm.start", nil, rtmStart); err != nil {
 		return nil, err
 	}
 
 	if rtmStart.OK != true {
-		return nil, fmt.Errorf("Error on rtm.start : %s", rtmStart.Error)
+		return nil, fmt.Errorf("failed rtm.start request: %s", rtmStart.Error)
 	}
 
 	return rtmStart, nil
@@ -74,9 +74,13 @@ func (g *Golack) StartRTMSession(ctx context.Context) (*webapi.RTMStart, error) 
 
 func (g *Golack) PostMessage(ctx context.Context, postMessage *webapi.PostMessage) (*webapi.APIResponse, error) {
 	response := &webapi.APIResponse{}
-	err := g.webClient.Post(ctx, "chat.postMessage", postMessage.ToURLValues(), &response)
+	err := g.webClient.Post(ctx, "chat.postMessage", postMessage.ToURLValues(), response)
 	if err != nil {
 		return nil, err
+	}
+
+	if response.OK != true {
+		return nil, fmt.Errorf("failed chat.postMessage request: %s", response.Error)
 	}
 
 	return response, nil

--- a/webapi/client.go
+++ b/webapi/client.go
@@ -74,6 +74,8 @@ func (client *Client) Get(ctx context.Context, slackMethod string, queryParams *
 	}
 
 	defer resp.Body.Close()
+	// Usually, the API returns a JSON structure with status code 200.
+	// https://api.slack.com/web#evaluating_responses
 	if resp.StatusCode != http.StatusOK {
 		return statusErr(resp)
 	}
@@ -91,9 +93,12 @@ func (client *Client) Get(ctx context.Context, slackMethod string, queryParams *
 }
 
 func statusErr(resp *http.Response) error {
-	reqDump, reqErr := httputil.DumpRequestOut(resp.Request, true)
-	if reqErr != nil {
-		reqDump = []byte("N/A")
+	reqDump := []byte("N/A")
+	if resp.Request != nil {
+		dump, err := httputil.DumpRequestOut(resp.Request, true)
+		if err != nil {
+			reqDump = dump
+		}
 	}
 
 	resDump, resErr := httputil.DumpResponse(resp, true)
@@ -115,6 +120,8 @@ func (client *Client) Post(ctx context.Context, slackMethod string, bodyParam ur
 	}
 
 	defer resp.Body.Close()
+	// Usually, the API returns a JSON structure with status code 200.
+	// https://api.slack.com/web#evaluating_responses
 	if resp.StatusCode != http.StatusOK {
 		return statusErr(resp)
 	}

--- a/webapi/client_test.go
+++ b/webapi/client_test.go
@@ -14,18 +14,38 @@ type GetResponseDummy struct {
 	Foo string
 }
 
+func TestWithHTTPClient(t *testing.T) {
+	httpClient := &http.Client{}
+	option := WithHTTPClient(httpClient)
+	client := &Client{}
+
+	option(client)
+
+	if client.httpClient != httpClient {
+		t.Errorf("Specified htt.Client is not set")
+	}
+}
+
 func TestNewClient(t *testing.T) {
 	config := &Config{Token: "abc", RequestTimeout: 1 * time.Second}
-	client := NewClient(config)
+	optionCalled := false
+	client := NewClient(config, func(*Client) { optionCalled = true })
 
 	if client == nil {
-		t.Fatal("client is nil.")
+		t.Fatal("Returned client is nil.")
 	}
 
 	if client.config != config {
-		t.Errorf("returned client does not have assigned config: %#v.", client.config)
+		t.Errorf("Returned client does not have assigned config: %#v.", client.config)
 	}
 
+	if !optionCalled {
+		t.Error("ClientOption is not called.")
+	}
+
+	if client.httpClient != http.DefaultClient {
+		t.Errorf("When WithHTTPClient is not given, http.DefaultClient must be set: %+v", client.httpClient)
+	}
 }
 
 func Test_buildEndpoint(t *testing.T) {

--- a/webapi/client_test.go
+++ b/webapi/client_test.go
@@ -1,12 +1,14 @@
 package webapi
 
 import (
-	"github.com/jarcoal/httpmock"
-	"golang.org/x/net/context"
+	"encoding/json"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"testing"
 	"time"
+
+	"golang.org/x/net/context"
 )
 
 type GetResponseDummy struct {
@@ -72,17 +74,19 @@ func Test_buildEndpoint(t *testing.T) {
 }
 
 func TestClient_Get(t *testing.T) {
-	httpmock.Activate()
-	defer httpmock.DeactivateAndReset()
-
 	returningResponse := &GetResponseDummy{
 		APIResponse: APIResponse{OK: true},
 		Foo:         "bar",
 	}
-	responder, _ := httpmock.NewJsonResponder(200, returningResponse)
-	httpmock.RegisterResponder("GET", "https://slack.com/api/foo", responder)
+	tripper := buildRoundTripper(http.MethodGet, "/api/foo", returningResponse)
+	client := &Client{
+		config: &Config{
+			Token:          "abc",
+			RequestTimeout: 3 * time.Second,
+		},
+		httpClient: &http.Client{Transport: tripper},
+	}
 
-	client := &Client{config: &Config{Token: "abc", RequestTimeout: 3 * time.Second}}
 	returnedResponse := &GetResponseDummy{}
 	err := client.Get(context.TODO(), "foo", nil, returnedResponse)
 
@@ -100,36 +104,42 @@ func TestClient_Get(t *testing.T) {
 }
 
 func TestClient_Get_StatusError(t *testing.T) {
-	httpmock.Activate()
-	defer httpmock.DeactivateAndReset()
-
-	statusCode := 404
-	responder := func(req *http.Request) (*http.Response, error) {
-		resp := httpmock.NewStringResponse(statusCode, "foo bar")
-		resp.Request = req // To let *http.Response.Request work
-		return resp, nil
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/foo", func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	tripper := &localRoundTripper{mux: mux}
+	client := &Client{
+		config: &Config{
+			Token:          "abc",
+			RequestTimeout: 3 * time.Second,
+		},
+		httpClient: &http.Client{Transport: tripper},
 	}
-	httpmock.RegisterResponder("GET", "https://slack.com/api/foo", responder)
 
-	client := &Client{config: &Config{Token: "abc", RequestTimeout: 3 * time.Second}}
-	returnedResponse := &GetResponseDummy{}
-	err := client.Get(context.TODO(), "foo", nil, returnedResponse)
+	err := client.Get(context.TODO(), "foo", nil, &GetResponseDummy{})
 
 	if err == nil {
-		t.Errorf("error should return when %d is given.", statusCode)
+		t.Error("error should return when 404 is given.")
 	}
 }
 
 func TestClient_Get_JSONError(t *testing.T) {
-	httpmock.Activate()
-	defer httpmock.DeactivateAndReset()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/foo", func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("invalid json"))
+	})
+	tripper := &localRoundTripper{mux: mux}
+	client := &Client{
+		config: &Config{
+			Token:          "abc",
+			RequestTimeout: 3 * time.Second,
+		},
+		httpClient: &http.Client{Transport: tripper},
+	}
 
-	responder := httpmock.NewStringResponder(200, "invalid json")
-	httpmock.RegisterResponder("GET", "https://slack.com/api/foo", responder)
-
-	client := &Client{config: &Config{Token: "abc", RequestTimeout: 3 * time.Second}}
-	returnedResponse := &GetResponseDummy{}
-	err := client.Get(context.TODO(), "foo", nil, returnedResponse)
+	err := client.Get(context.TODO(), "foo", nil, &GetResponseDummy{})
 
 	if err == nil {
 		t.Error("error should return")
@@ -137,13 +147,15 @@ func TestClient_Get_JSONError(t *testing.T) {
 }
 
 func TestClient_Post(t *testing.T) {
-	httpmock.Activate()
-	defer httpmock.DeactivateAndReset()
+	tripper := buildRoundTripper(http.MethodPost, "/api/foo", &APIResponse{OK: true})
+	client := &Client{
+		config: &Config{
+			Token:          "abc",
+			RequestTimeout: 3 * time.Second,
+		},
+		httpClient: &http.Client{Transport: tripper},
+	}
 
-	responder, _ := httpmock.NewJsonResponder(200, &APIResponse{OK: true})
-	httpmock.RegisterResponder("POST", "https://slack.com/api/foo", responder)
-
-	client := &Client{config: &Config{Token: "abc", RequestTimeout: 3 * time.Second}}
 	returnedResponse := &APIResponse{}
 	err := client.Post(context.TODO(), "foo", url.Values{}, returnedResponse)
 
@@ -153,22 +165,56 @@ func TestClient_Post(t *testing.T) {
 }
 
 func TestPostStatusError(t *testing.T) {
-	httpmock.Activate()
-	defer httpmock.DeactivateAndReset()
-
-	statusCode := 404
-	responder := func(req *http.Request) (*http.Response, error) {
-		resp := httpmock.NewStringResponse(statusCode, "foo bar")
-		resp.Request = req // To let *http.Response.Request work
-		return resp, nil
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/foo", func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	tripper := &localRoundTripper{mux: mux}
+	client := &Client{
+		config: &Config{
+			Token:          "abc",
+			RequestTimeout: 3 * time.Second,
+		},
+		httpClient: &http.Client{Transport: tripper},
 	}
-	httpmock.RegisterResponder("POST", "https://slack.com/api/foo", responder)
 
-	client := &Client{config: &Config{Token: "abc", RequestTimeout: 3 * time.Second}}
 	returnedResponse := &APIResponse{}
 	err := client.Post(context.TODO(), "foo", url.Values{}, returnedResponse)
 
 	if err == nil {
-		t.Errorf("error should return when %d is given.", statusCode)
+		t.Error("error should return when 500 is given.")
 	}
+}
+
+func buildRoundTripper(method string, path string, response interface{}) *localRoundTripper {
+	mux := http.NewServeMux()
+	mux.HandleFunc(path, func(w http.ResponseWriter, req *http.Request) {
+		if req.Method != method {
+			code := http.StatusMethodNotAllowed
+			http.Error(w, http.StatusText(code), code)
+		}
+		bytes, err := json.Marshal(response)
+		if err != nil {
+			code := http.StatusInternalServerError
+			http.Error(w, http.StatusText(code), code)
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, err = w.Write(bytes)
+		if err != nil {
+			code := http.StatusInternalServerError
+			http.Error(w, http.StatusText(code), code)
+		}
+	})
+	return &localRoundTripper{mux: mux}
+}
+
+type localRoundTripper struct {
+	mux *http.ServeMux
+}
+
+func (l *localRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	w := httptest.NewRecorder()
+	l.mux.ServeHTTP(w, req)
+	return w.Result(), nil
 }


### PR DESCRIPTION
This p-r fixes #4
To remove github.com/jarcoal/httpmock, this adopt `http.RoundTripper` implementation to mock HTTP request/response. This requires occasional `*http.Client` switch. In the course of this modification, this p-r let `Golack` and `webapi.Client` accept functional option on construction. This should have no effect on current usage because this uses variadic arguments to receive options.