### PR TITLE
Migrate x/net/context to standard context

### DIFF
--- a/golack.go
+++ b/golack.go
@@ -1,13 +1,13 @@
 package golack
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"time"
 
 	"github.com/oklahomer/golack/rtmapi"
 	"github.com/oklahomer/golack/webapi"
-	"golang.org/x/net/context"
 )
 
 type Config struct {

--- a/golack_test.go
+++ b/golack_test.go
@@ -1,11 +1,10 @@
 package golack
 
 import (
+	"context"
+	"github.com/oklahomer/golack/webapi"
 	"net/url"
 	"testing"
-
-	"github.com/oklahomer/golack/webapi"
-	"golang.org/x/net/context"
 )
 
 type DummyWebClient struct {

--- a/rtmapi/connection.go
+++ b/rtmapi/connection.go
@@ -1,6 +1,7 @@
 package rtmapi
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -11,7 +12,6 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/oklahomer/golack/slackobject"
 	"github.com/tidwall/gjson"
-	"golang.org/x/net/context"
 )
 
 var (

--- a/rtmapi/connection_test.go
+++ b/rtmapi/connection_test.go
@@ -1,11 +1,11 @@
 package rtmapi
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"github.com/gorilla/websocket"
 	"github.com/oklahomer/golack/slackobject"
-	"golang.org/x/net/context"
 	"net/http"
 	"net/http/httptest"
 	"reflect"

--- a/webapi/client_test.go
+++ b/webapi/client_test.go
@@ -1,14 +1,13 @@
 package webapi
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"testing"
 	"time"
-
-	"golang.org/x/net/context"
 )
 
 type GetResponseDummy struct {
@@ -157,7 +156,9 @@ func TestClient_Post(t *testing.T) {
 	}
 
 	returnedResponse := &APIResponse{}
-	err := client.Post(context.TODO(), "foo", url.Values{}, returnedResponse)
+	values := url.Values{}
+	values.Set("foo", "bar")
+	err := client.Post(context.TODO(), "foo", values, returnedResponse)
 
 	if err != nil {
 		t.Errorf("something is wrong. %#v", err)


### PR DESCRIPTION
Since this package supports Golang 1.7. This is safe to use context instead of old `x/net/context`.
ref. https://golang.org/doc/go1.7#context