### PR TITLE
Organize field names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,3 +25,6 @@ matrix:
 
 git:
   depth: 10
+
+env:
+  - GO111MODULE=on

--- a/rtmapi/connection.go
+++ b/rtmapi/connection.go
@@ -128,7 +128,7 @@ var (
 		FileCommentEditedEvent:     reflect.TypeOf(&FileCommentEdited{}).Elem(),
 		FileCreatedEvent:           reflect.TypeOf(&FileCreated{}).Elem(),
 		FileDeletedEvent:           reflect.TypeOf(&FileDeleted{}).Elem(),
-		FilePublicEvent:            reflect.TypeOf(&FilePublicated{}).Elem(),
+		FilePublicEvent:            reflect.TypeOf(&FilePublished{}).Elem(),
 		FileSharedEvent:            reflect.TypeOf(&FileShared{}).Elem(),
 		FileUnsharedEvent:          reflect.TypeOf(&FileUnshared{}).Elem(),
 		GoodByeEvent:               reflect.TypeOf(&GoodBye{}).Elem(),

--- a/rtmapi/connection_test.go
+++ b/rtmapi/connection_test.go
@@ -145,8 +145,8 @@ func TestConnWrapper_Receive(t *testing.T) {
 		t.Errorf("expected channel name is not given: %s.", message.ChannelID.String())
 	}
 
-	if message.Sender != userID {
-		t.Errorf("expected user is not given: %s.", message.Sender)
+	if message.SenderID != userID {
+		t.Errorf("expected user is not given: %s.", message.SenderID)
 	}
 
 	if message.Text != text {

--- a/rtmapi/incoming_event.go
+++ b/rtmapi/incoming_event.go
@@ -12,7 +12,7 @@ type Bot struct {
 	ID    slackobject.BotID `json:"id"`
 	AppID slackobject.AppID `json:"app_id"`
 	Name  string            `json:"name"`
-	Icons *struct {
+	Icon  *struct {
 		Image48 string `json:"image_48"`
 	} `json:"icons"`
 }
@@ -30,16 +30,16 @@ type BotChanged struct {
 type ChannelArchived struct {
 	TypedEvent
 	ChannelID slackobject.ChannelID `json:"channel"`
-	User      slackobject.UserID    `json:"user"`
+	UserID    slackobject.UserID    `json:"user"`
 }
 
 type ChannelCreated struct {
 	TypedEvent
 	Channel *struct {
-		ID      slackobject.ChannelID `json:"id"`
-		Name    string                `json:"name"`
-		Created *TimeStamp            `json:"created"`
-		Creator string                `json:"creator"`
+		ID        slackobject.ChannelID `json:"id"`
+		Name      string                `json:"name"`
+		Created   *TimeStamp            `json:"created"`
+		CreatorID slackobject.UserID    `json:"creator"`
 	} `json:"channel"`
 }
 
@@ -91,7 +91,7 @@ type ChannelRenamed struct {
 type ChannelUnarchived struct {
 	TypedEvent
 	ChannelID slackobject.ChannelID `json:"channel"`
-	User      slackobject.UserID    `json:"user"`
+	UserID    slackobject.UserID    `json:"user"`
 }
 
 type CommandsChanged struct {
@@ -101,7 +101,7 @@ type CommandsChanged struct {
 
 type DNDUpdated struct {
 	TypedEvent
-	User      slackobject.UserID `json:"user"`
+	UserID    slackobject.UserID `json:"user"`
 	DNDStatus *struct {
 		Enabled            bool       `json:"dnd_enabled"`
 		NextStartTimeStamp *TimeStamp `json:"next_dnd_start_ts"`
@@ -113,7 +113,7 @@ type DNDUpdated struct {
 
 type DNDUpdatedUser struct {
 	TypedEvent
-	User      slackobject.UserID `json:"user"`
+	UserID    slackobject.UserID `json:"user"`
 	DNDStatus *struct {
 		Enabled            bool       `json:"dnd_enabled"`
 		NextStartTimeStamp *TimeStamp `json:"next_dnd_start_ts"`
@@ -135,10 +135,10 @@ type EmojiChanged struct {
 }
 
 type Comment struct {
-	ID      string             `json:"id"`
-	Created *TimeStamp         `json:"created"`
-	User    slackobject.UserID `json:"user"`
-	Content string             `json:"comment"`
+	ID      slackobject.CommentID `json:"id"`
+	Created *TimeStamp            `json:"created"`
+	UserID  slackobject.UserID    `json:"user"`
+	Content string                `json:"comment"`
 }
 
 // https://api.slack.com/types/file
@@ -153,7 +153,7 @@ type File struct {
 	MimeType           string                  `json:"mimetype"`
 	FileType           string                  `json:"filetype"`
 	PrettyType         string                  `json:"pretty_type"`
-	User               slackobject.UserID      `json:"user"`
+	UserID             slackobject.UserID      `json:"user"`
 	Mode               string                  `json:"mode"`
 	Editable           bool                    `json:"editable"`
 	IsExternal         bool                    `json:"is_external"`
@@ -182,7 +182,7 @@ type File struct {
 	IsPublic           bool                    `json:"is_public"`
 	PublicURLShared    bool                    `json:"public_url_shared"`
 	DisplayAsBot       bool                    `json:"display_as_bot"`
-	Channels           []slackobject.ChannelID `json:"channels"`
+	ChannelIDs         []slackobject.ChannelID `json:"channels"`
 	Groups             []string                `json:"groups"`
 	Ims                []string                `json:"ims"`
 	InitialComment     *Comment                `json:"initial_comment"`
@@ -190,9 +190,9 @@ type File struct {
 	IsStarred          bool                    `json:"is_starred"`
 	PinnedTo           []string                `json:"pinned_to"`
 	Reactions          []*struct {
-		Name  string               `json:"name"`
-		Count int                  `json:"count"`
-		Users []slackobject.UserID `json:"users"`
+		Name    string               `json:"name"`
+		Count   int                  `json:"count"`
+		UserIDs []slackobject.UserID `json:"users"`
 	} `json:"reactions"`
 	CommentsCount int `json:"comments_count"`
 }
@@ -252,11 +252,11 @@ type FileCreated struct {
 
 type FileDeleted struct {
 	TypedEvent
-	FileID    string     `json:"file_id"`
-	TimeStamp *TimeStamp `json:"event_ts"`
+	FileID    slackobject.FileID `json:"file_id"`
+	TimeStamp *TimeStamp         `json:"event_ts"`
 }
 
-type FilePublicated struct {
+type FilePublished struct {
 	TypedEvent
 	FileID slackobject.FileID `json:"file_id"`
 	File   *struct {
@@ -297,7 +297,7 @@ type GroupArchived struct {
 
 type GroupClosed struct {
 	TypedEvent
-	User      slackobject.UserID    `json:"user"`
+	UserID    slackobject.UserID    `json:"user"`
 	ChannelID slackobject.ChannelID `json:"channel"`
 }
 
@@ -328,13 +328,13 @@ type GroupMarked struct {
 
 type GroupOpened struct {
 	TypedEvent
-	User      slackobject.UserID    `json:"user"`
+	UserID    slackobject.UserID    `json:"user"`
 	ChannelID slackobject.ChannelID `json:"channel"`
 }
 
 type GroupRenamed struct {
 	TypedEvent
-	Channel struct {
+	Channel *struct {
 		ID      slackobject.ChannelID `json:"id"`
 		Name    string                `json:"name"`
 		Created *TimeStamp            `json:"created"`
@@ -354,14 +354,14 @@ type Hello struct {
 
 type IMClosed struct {
 	TypedEvent
-	User      slackobject.UserID    `json:"user"`
+	UserID    slackobject.UserID    `json:"user"`
 	ChannelID slackobject.ChannelID `json:"channel"`
 }
 
 type IMCreated struct {
 	TypedEvent
-	User    slackobject.UserID `json:"user"`
-	Channel struct {
+	UserID  slackobject.UserID `json:"user"`
+	Channel *struct {
 		ID slackobject.ChannelID `json:"id"`
 	} `json:"channel"`
 }
@@ -378,7 +378,7 @@ type IMMarked struct {
 
 type IMOpened struct {
 	TypedEvent
-	User      slackobject.UserID    `json:"user"`
+	UserID    slackobject.UserID    `json:"user"`
 	ChannelID slackobject.ChannelID `json:"channel"`
 }
 
@@ -389,11 +389,11 @@ type PresenceManuallyChanged struct {
 
 type MemberJoinedChannel struct {
 	TypedEvent
-	User        slackobject.UserID    `json:"user"`
+	UserID      slackobject.UserID    `json:"user"`
 	ChannelID   slackobject.ChannelID `json:"channel"`
 	ChannelType string                `json:"channel_type"` // C or G. ref. https://api.slack.com/events/member_joined_channel
-	Team        slackobject.TeamID    `json:"team"`
-	Inviter     slackobject.UserID    `json:"inviter"` // Empty when the user joins by herself. ref. https://api.slack.com/events/member_joined_channel
+	TeamID      slackobject.TeamID    `json:"team"`
+	InviterID   slackobject.UserID    `json:"inviter"` // Empty when the user joins by herself. ref. https://api.slack.com/events/member_joined_channel
 }
 
 // Message represent message event on RTM.
@@ -412,24 +412,24 @@ type MemberJoinedChannel struct {
 type Message struct {
 	TypedEvent
 	ChannelID slackobject.ChannelID `json:"channel"`
-	Sender    slackobject.UserID    `json:"user"`
+	SenderID  slackobject.UserID    `json:"user"`
 	Text      string                `json:"text"`
 	TimeStamp *TimeStamp            `json:"ts"`
 }
 
 // Item can be any object with type of Message, File, or Comment.
 type Item struct {
-	Type      string     `json:"type"`
-	Channel   string     `json:"channel"`
-	Message   *Message   `json:"message"`
-	File      *File      `json:"file"`
-	Comment   *Comment   `json:"comment"`
-	TimeStamp *TimeStamp `json:"ts"`
+	Type      string                `json:"type"`
+	ChannelID slackobject.ChannelID `json:"channel"`
+	Message   *Message              `json:"message"`
+	File      *File                 `json:"file"`
+	Comment   *Comment              `json:"comment"`
+	TimeStamp *TimeStamp            `json:"ts"`
 }
 
 type PinAdded struct {
 	TypedEvent
-	User      slackobject.UserID    `json:"user"`
+	UserID    slackobject.UserID    `json:"user"`
 	ChannelID slackobject.ChannelID `json:"channel_id"`
 	TimeStamp *TimeStamp            `json:"event_ts"`
 	Item      *Item                 `json:"item"`
@@ -437,7 +437,7 @@ type PinAdded struct {
 
 type PinRemoved struct {
 	TypedEvent
-	User      slackobject.UserID    `json:"user"`
+	UserID    slackobject.UserID    `json:"user"`
 	ChannelID slackobject.ChannelID `json:"channel_id"`
 	Item      *Item                 `json:"item"`
 	HasPins   bool                  `json:"has_pins"`
@@ -452,36 +452,36 @@ type PreferenceChanged struct {
 
 type PresenceChange struct {
 	TypedEvent
-	User     slackobject.UserID `json:"user"`
+	UserID   slackobject.UserID `json:"user"`
 	Presence string             `json:"presence"`
 }
 
 type PresenceQuery struct {
 	TypedEvent
-	IDs []slackobject.UserID `json:"ids"`
+	UserIDs []slackobject.UserID `json:"ids"`
 }
 
 type PresenceSubscribe struct {
 	TypedEvent
-	IDs []slackobject.UserID `json:"ids"`
+	UserIDs []slackobject.UserID `json:"ids"`
 }
 
 type ReactionAdded struct {
 	TypedEvent
-	User      slackobject.UserID `json:"user"`
-	Reaction  string             `json:"reaction"` // TODO actual value
-	ItemOwner slackobject.UserID `json:"item_user"`
-	Item      *Item              `json:"item"` // TODO message, file, file comment. only ids are given, right?
-	TimeStamp *TimeStamp         `json:"event_ts"`
+	UserID      slackobject.UserID `json:"user"`
+	Reaction    string             `json:"reaction"` // TODO actual value
+	ItemOwnerID slackobject.UserID `json:"item_user"`
+	Item        *Item              `json:"item"` // TODO message, file, file comment. only ids are given, right?
+	TimeStamp   *TimeStamp         `json:"event_ts"`
 }
 
 type ReactionRemoved struct {
 	TypedEvent
-	User      slackobject.UserID `json:"user"`
-	Reaction  string             `json:"reaction"` // TODO actual value
-	ItemOwner string             `json:"item_user"`
-	Item      *Item              `json:"item"` // TODO message, file, file comment. only ids are given, right?
-	TimeStamp *TimeStamp         `json:"event_ts"`
+	UserID      slackobject.UserID `json:"user"`
+	Reaction    string             `json:"reaction"` // TODO actual value
+	ItemOwnerID string             `json:"item_user"`
+	Item        *Item              `json:"item"` // TODO message, file, file comment. only ids are given, right?
+	TimeStamp   *TimeStamp         `json:"event_ts"`
 }
 
 // ReconnectURL is currently unsupported and experimental
@@ -492,14 +492,14 @@ type ReconnectURL struct {
 
 type StarAdded struct {
 	TypedEvent
-	User      slackobject.UserID `json:"user"`
+	UserID    slackobject.UserID `json:"user"`
 	Item      *Item              `json:"item"` // TODO message, file, file comment. only ids are given, right?
 	TimeStamp *TimeStamp         `json:"event_ts"`
 }
 
 type StarRemoved struct {
 	TypedEvent
-	User      slackobject.UserID `json:"user"`
+	UserID    slackobject.UserID `json:"user"`
 	Item      *Item              `json:"item"` // TODO message, file, file comment. only ids are given, right?
 	TimeStamp *TimeStamp         `json:"event_ts"`
 }
@@ -516,10 +516,10 @@ type SubTeam struct {
 	Updated     *TimeStamp            `json:"date_update"`
 	Deleted     *TimeStamp            `json:"date_delete"`
 	AutoType    string                `json:"auto_type"`
-	CreatedBy   slackobject.UserID    `json:"created_by"`
+	CreatorID   slackobject.UserID    `json:"created_by"`
 	UpdatedBy   string                `json:"updated_by"`
 	UserCount   int                   `json:"user_count,string"`
-	Users       []slackobject.UserID  `json:"users"`
+	UserIDs     []slackobject.UserID  `json:"users"`
 }
 
 type SubTeamCreated struct {
@@ -532,10 +532,10 @@ type SubTeamMembersChanged struct {
 	SubTeamID         slackobject.SubTeamID `json:"subteam_id"`
 	TeamID            slackobject.TeamID    `json:"team_id"`
 	PreviousUpdate    *TimeStamp            `json:"date_previous_update"`
-	Update            *TimeStamp            `json:"date_update"`
-	AddedUsers        []slackobject.UserID  `json:"added_users"`
+	Updated           *TimeStamp            `json:"date_update"`
+	AddedUserIDs      []slackobject.UserID  `json:"added_users"`
 	AddedUserCount    int                   `json:"added_users_count,string"`
-	RemovedUsers      []slackobject.UserID  `json:"removed_users"`
+	RemovedUserIDs    []slackobject.UserID  `json:"removed_users"`
 	RemovedUsersCount int                   `json:"removed_users_count,string"`
 }
 
@@ -663,7 +663,7 @@ type UserChanged struct {
 type UserTyping struct {
 	TypedEvent
 	ChannelID slackobject.ChannelID `json:"channel"`
-	User      slackobject.UserID    `json:"user"`
+	UserID    slackobject.UserID    `json:"user"`
 }
 
 // Pong is given when client send Ping.

--- a/rtmapi/incoming_event_test.go
+++ b/rtmapi/incoming_event_test.go
@@ -22,7 +22,7 @@ var expectedPayloads = map[EventType]EventTyper{
 			ID:    "B024BE7LH",
 			AppID: "A4H1JB4AZ",
 			Name:  "hugbot",
-			Icons: &struct {
+			Icon: &struct {
 				Image48 string `json:"image_48"`
 			}{
 				Image48: "https://slack.com/path/to/hugbot_48.png",
@@ -34,7 +34,7 @@ var expectedPayloads = map[EventType]EventTyper{
 			ID:    "B024BE7LH",
 			AppID: "A4H1JB4AZ",
 			Name:  "hugbot",
-			Icons: &struct {
+			Icon: &struct {
 				Image48 string `json:"image_48"`
 			}{
 				Image48: "https://slack.com/path/to/hugbot_48.png",
@@ -43,14 +43,14 @@ var expectedPayloads = map[EventType]EventTyper{
 	},
 	ChannelArchivedEvent: &ChannelArchived{
 		ChannelID: "C024BE91L",
-		User:      "U024BE7LH",
+		UserID:    "U024BE7LH",
 	},
 	ChannelCreatedEvent: &ChannelCreated{
 		Channel: &struct {
-			ID      slackobject.ChannelID `json:"id"`
-			Name    string                `json:"name"`
-			Created *TimeStamp            `json:"created"`
-			Creator string                `json:"creator"`
+			ID        slackobject.ChannelID `json:"id"`
+			Name      string                `json:"name"`
+			Created   *TimeStamp            `json:"created"`
+			CreatorID slackobject.UserID    `json:"creator"`
 		}{
 			ID:   "C024BE91L",
 			Name: "fun",
@@ -58,7 +58,7 @@ var expectedPayloads = map[EventType]EventTyper{
 				Time:          time.Unix(1360782804, 0),
 				OriginalValue: "1360782804",
 			},
-			Creator: "U024BE7LH",
+			CreatorID: "U024BE7LH",
 		},
 	},
 	ChannelDeletedEvent: &ChannelDeleted{
@@ -111,7 +111,7 @@ var expectedPayloads = map[EventType]EventTyper{
 	},
 	ChannelUnarchiveEvent: &ChannelUnarchived{
 		ChannelID: "C024BE91L",
-		User:      "U024BE7LH",
+		UserID:    "U024BE7LH",
 	},
 	CommandsChangedEvent: &CommandsChanged{
 		TimeStamp: &TimeStamp{
@@ -120,7 +120,7 @@ var expectedPayloads = map[EventType]EventTyper{
 		},
 	},
 	DNDUpdatedEvent: &DNDUpdated{
-		User: "U1234",
+		UserID: "U1234",
 		DNDStatus: &struct {
 			Enabled            bool       `json:"dnd_enabled"`
 			NextStartTimeStamp *TimeStamp `json:"next_dnd_start_ts"`
@@ -145,7 +145,7 @@ var expectedPayloads = map[EventType]EventTyper{
 		},
 	},
 	DNDUpdatedUserEvent: &DNDUpdatedUser{
-		User: "U1234",
+		UserID: "U1234",
 		DNDStatus: &struct {
 			Enabled            bool       `json:"dnd_enabled"`
 			NextStartTimeStamp *TimeStamp `json:"next_dnd_start_ts"`
@@ -198,7 +198,7 @@ var expectedPayloads = map[EventType]EventTyper{
 				Time:          time.Unix(1360782804, 0),
 				OriginalValue: "1360782804",
 			},
-			User:    "U1234",
+			UserID:  "U1234",
 			Content: "comment content",
 		},
 	},
@@ -224,7 +224,7 @@ var expectedPayloads = map[EventType]EventTyper{
 				Time:          time.Unix(1360782804, 0),
 				OriginalValue: "1360782804",
 			},
-			User:    "U1234",
+			UserID:  "U1234",
 			Content: "comment content",
 		},
 	},
@@ -243,7 +243,7 @@ var expectedPayloads = map[EventType]EventTyper{
 			OriginalValue: "1361482916.000004",
 		},
 	},
-	FilePublicEvent: &FilePublicated{
+	FilePublicEvent: &FilePublished{
 		FileID: "F2147483862",
 		File: &struct {
 			ID slackobject.FileID `json:"id"`
@@ -272,7 +272,7 @@ var expectedPayloads = map[EventType]EventTyper{
 		ChannelID: "G024BE91L",
 	},
 	GroupCloseEvent: &GroupClosed{
-		User:      "U024BE7LH",
+		UserID:    "U024BE7LH",
 		ChannelID: "G024BE91L",
 	},
 	GroupDeletedEvent: &GroupDeleted{
@@ -310,11 +310,11 @@ var expectedPayloads = map[EventType]EventTyper{
 		},
 	},
 	GroupOpenEvent: &GroupOpened{
-		User:      "U024BE7LH",
+		UserID:    "U024BE7LH",
 		ChannelID: "G024BE91L",
 	},
 	GroupRenameEvent: &GroupRenamed{
-		Channel: struct {
+		Channel: &struct {
 			ID      slackobject.ChannelID `json:"id"`
 			Name    string                `json:"name"`
 			Created *TimeStamp            `json:"created"`
@@ -332,12 +332,12 @@ var expectedPayloads = map[EventType]EventTyper{
 	},
 	HelloEvent: &Hello{},
 	IMCloseEvent: &IMClosed{
-		User:      "U024BE7LH",
+		UserID:    "U024BE7LH",
 		ChannelID: "D024BE91L",
 	},
 	IMCreatedEvent: &IMCreated{
-		User: "U024BE7LH",
-		Channel: struct {
+		UserID: "U024BE7LH",
+		Channel: &struct {
 			ID slackobject.ChannelID `json:"id"`
 		}{
 			ID: "D024BE91L",
@@ -360,22 +360,22 @@ var expectedPayloads = map[EventType]EventTyper{
 		},
 	},
 	IMOpenEvent: &IMOpened{
-		User:      "U024BE7LH",
+		UserID:    "U024BE7LH",
 		ChannelID: "D024BE91L",
 	},
 	ManualPresenceChangeEvent: &PresenceManuallyChanged{
 		Presence: "away",
 	},
 	MemberJoinedChannelEvent: &MemberJoinedChannel{
-		User:        "W06GH7XHN",
+		UserID:      "W06GH7XHN",
 		ChannelID:   "C0698JE0H",
 		ChannelType: "C",
-		Team:        "T024BE7LD",
-		Inviter:     "U123456789",
+		TeamID:      "T024BE7LD",
+		InviterID:   "U123456789",
 	},
 	MessageEvent: &Message{
 		ChannelID: "C2147483705",
-		Sender:    "U2147483697",
+		SenderID:  "U2147483697",
 		Text:      "Hello world",
 		TimeStamp: &TimeStamp{
 			Time:          time.Unix(1355517523, 0),
@@ -383,7 +383,7 @@ var expectedPayloads = map[EventType]EventTyper{
 		},
 	},
 	PinAddedEvent: &PinAdded{
-		User:      "U024BE7LH",
+		UserID:    "U024BE7LH",
 		ChannelID: "C02ELGNBH",
 		TimeStamp: &TimeStamp{
 			Time:          time.Unix(1360782804, 0),
@@ -391,7 +391,7 @@ var expectedPayloads = map[EventType]EventTyper{
 		},
 	},
 	PinRemovedEvent: &PinRemoved{
-		User:      "U024BE7LH",
+		UserID:    "U024BE7LH",
 		ChannelID: "C02ELGNBH",
 		HasPins:   false,
 		TimeStamp: &TimeStamp{
@@ -404,28 +404,28 @@ var expectedPayloads = map[EventType]EventTyper{
 		Value: "dense",
 	},
 	PresenceChangeEvent: &PresenceChange{
-		User:     "U024BE7LH",
+		UserID:   "U024BE7LH",
 		Presence: "away",
 	},
 	PresenceQueryEvent: &PresenceQuery{
-		IDs: []slackobject.UserID{
+		UserIDs: []slackobject.UserID{
 			"U061F7AUR",
 			"W123456",
 		},
 	},
 	PresenceSubEvent: &PresenceSubscribe{
-		IDs: []slackobject.UserID{
+		UserIDs: []slackobject.UserID{
 			"U061F7AUR",
 			"W123456",
 		},
 	},
 	ReactionAddedEvent: &ReactionAdded{
-		User:      "U024BE7LH",
-		Reaction:  "thumbsup",
-		ItemOwner: "U0G9QF9C6",
+		UserID:      "U024BE7LH",
+		Reaction:    "thumbsup",
+		ItemOwnerID: "U0G9QF9C6",
 		Item: &Item{
-			Type:    "message",
-			Channel: "C0G9QF9GZ",
+			Type:      "message",
+			ChannelID: "C0G9QF9GZ",
 			TimeStamp: &TimeStamp{
 				Time:          time.Unix(1360782400, 0),
 				OriginalValue: "1360782400.498405",
@@ -437,12 +437,12 @@ var expectedPayloads = map[EventType]EventTyper{
 		},
 	},
 	ReactionRemovedEvent: &ReactionRemoved{
-		User:      "U024BE7LH",
-		Reaction:  "thumbsup",
-		ItemOwner: "U0G9QF9C6",
+		UserID:      "U024BE7LH",
+		Reaction:    "thumbsup",
+		ItemOwnerID: "U0G9QF9C6",
 		Item: &Item{
-			Type:    "message",
-			Channel: "C0G9QF9GZ",
+			Type:      "message",
+			ChannelID: "C0G9QF9GZ",
 			TimeStamp: &TimeStamp{
 				Time:          time.Unix(1360782400, 0),
 				OriginalValue: "1360782400.498405",
@@ -455,10 +455,10 @@ var expectedPayloads = map[EventType]EventTyper{
 	},
 	ReconnectURLEvent: &ReconnectURL{},
 	StarAddedEvent: &StarAdded{
-		User: "U024BE7LH",
+		UserID: "U024BE7LH",
 		Item: &Item{
-			Type:    "message",
-			Channel: "C0G9QF9GZ",
+			Type:      "message",
+			ChannelID: "C0G9QF9GZ",
 			TimeStamp: &TimeStamp{
 				Time:          time.Unix(1360782400, 0),
 				OriginalValue: "1360782400.498405",
@@ -470,10 +470,10 @@ var expectedPayloads = map[EventType]EventTyper{
 		},
 	},
 	StarRemovedEvent: &StarRemoved{
-		User: "U024BE7LH",
+		UserID: "U024BE7LH",
 		Item: &Item{
-			Type:    "message",
-			Channel: "C0G9QF9GZ",
+			Type:      "message",
+			ChannelID: "C0G9QF9GZ",
 			TimeStamp: &TimeStamp{
 				Time:          time.Unix(1360782400, 0),
 				OriginalValue: "1360782400.498405",
@@ -506,7 +506,7 @@ var expectedPayloads = map[EventType]EventTyper{
 				OriginalValue: "1446746793",
 			},
 			AutoType:  "",
-			CreatedBy: "U060RNRCZ",
+			CreatorID: "U060RNRCZ",
 			UpdatedBy: "U060RNRCZ",
 			UserCount: 10,
 		},
@@ -518,17 +518,17 @@ var expectedPayloads = map[EventType]EventTyper{
 			Time:          time.Unix(1446670362, 0),
 			OriginalValue: "1446670362",
 		},
-		Update: &TimeStamp{
+		Updated: &TimeStamp{
 			Time:          time.Unix(1492906952, 0),
 			OriginalValue: "1492906952",
 		},
-		AddedUsers: []slackobject.UserID{
+		AddedUserIDs: []slackobject.UserID{
 			"U060RNRCZ",
 			"U060ULRC0",
 			"U061309JM",
 		},
 		AddedUserCount: 3,
-		RemovedUsers: []slackobject.UserID{
+		RemovedUserIDs: []slackobject.UserID{
 			"U06129G2V",
 		},
 		RemovedUsersCount: 1,
@@ -561,10 +561,10 @@ var expectedPayloads = map[EventType]EventTyper{
 				OriginalValue: "0",
 			},
 			AutoType:  "admin",
-			CreatedBy: "USLACKBOT",
+			CreatorID: "USLACKBOT",
 			UpdatedBy: "U060RNRCZ",
 			UserCount: 4,
-			Users: []slackobject.UserID{
+			UserIDs: []slackobject.UserID{
 				"U060RNRCZ",
 				"U060ULRC0",
 				"U06129G2V",
@@ -642,7 +642,7 @@ var expectedPayloads = map[EventType]EventTyper{
 	},
 	UserTypingEvent: &UserTyping{
 		ChannelID: "C02ELGNBH",
-		User:      "U024BE7LH",
+		UserID:    "U024BE7LH",
 	},
 }
 

--- a/rtmapi/outgoing_event.go
+++ b/rtmapi/outgoing_event.go
@@ -20,15 +20,15 @@ type OutgoingEvent struct {
 // https://api.slack.com/rtm#sending_messages
 type OutgoingMessage struct {
 	OutgoingEvent
-	Channel slackobject.ChannelID `json:"channel"`
-	Text    string                `json:"text"`
+	ChannelID slackobject.ChannelID `json:"channel"`
+	Text      string                `json:"text"`
 }
 
 // NewOutgoingMessage is a constructor to create new OutgoingMessage instance with given arguments.
 func NewOutgoingMessage(eventID *OutgoingEventID, channel slackobject.ChannelID, text string) *OutgoingMessage {
 	return &OutgoingMessage{
-		Channel: channel,
-		Text:    text,
+		ChannelID: channel,
+		Text:      text,
 		OutgoingEvent: OutgoingEvent{
 			ID: eventID.Next(),
 			TypedEvent: TypedEvent{

--- a/rtmapi/outgoing_event_id.go
+++ b/rtmapi/outgoing_event_id.go
@@ -2,7 +2,7 @@ package rtmapi
 
 import "sync"
 
-// OutgoingEventID manages posting payloads' unique IDs.
+// OutgoingEventID manages posting payloads' unique UserIDs.
 // https://api.slack.com/rtm#sending_messages
 type OutgoingEventID struct {
 	id    uint

--- a/slackobject/id.go
+++ b/slackobject/id.go
@@ -41,3 +41,9 @@ type SubTeamID string
 func (id SubTeamID) String() string {
 	return string(id)
 }
+
+type CommentID string
+
+func (id CommentID) String() string {
+	return string(id)
+}

--- a/webapi/response.go
+++ b/webapi/response.go
@@ -35,7 +35,7 @@ type UserProfile struct {
 	Title              string `json:"title"`
 }
 
-// User contains all the information of a user
+// SenderID contains all the information of a user
 type User struct {
 	User              string      `json:"user"`
 	Name              string      `json:"name"`


### PR DESCRIPTION
Sometimes a field called `User` refers to `User` object while sometimes refer to `slackobject.UserID`.
This p-r tries to organize such ambiguity. This should not involve any logic modification.