### PR TITLE
Organize supported golang ver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,16 +10,11 @@ go:
 before_install:
   - export PATH=$HOME/gopath/bin:$PATH
   - go get github.com/mattn/goveralls
-  - go get github.com/modocache/gover
 
 script:
   - go test -race ./...
-  - go test -coverprofile=golack.coverprofile .
-  - go test -coverprofile=rtmapi.coverprofile ./rtmapi
-  - go test -coverprofile=slackobject.coverprofile ./slackobject
-  - go test -coverprofile=webapi.coverprofile ./webapi
-  - gover
-  - goveralls -coverprofile=gover.coverprofile -service=travis-ci
+  - go test -coverprofile=coverage.out -cover ./...
+  - goveralls -coverprofile=coverage.out -service=travis-ci
 
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,9 @@ language: go
 sudo: false
 
 go:
-  - "1.7"
-  - "1.8"
-  - "1.9"
-  - "1.10"
-  - "1.11.4"
   - "1.12"
+  - "1.13"
+  - "1.14"
   - "tip"
 
 before_install:


### PR DESCRIPTION
Following the same policy as https://github.com/oklahomer/go-sarah#supported-golang-versions, this updates the list of supported Golang versions. Some workarounds to support older versions than 1.12 may be removed including https://github.com/oklahomer/go-sarah/pull/100.