### PR TITLE
Refine higher level interface

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
 script:
   - go test -race ./...
   - go test -coverprofile=coverage.out -cover ./...
-  - goveralls -coverprofile=coverage.out -service=travis-ci -ignore=examples/*/*.go,examples/*/*/*.go
+  - goveralls -coverprofile=coverage.out -service=travis-ci -ignore=examples/*/*.go,examples/*/*/*.go,testutil/*.go
 
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
 script:
   - go test -race ./...
   - go test -coverprofile=coverage.out -cover ./...
-  - goveralls -coverprofile=coverage.out -service=travis-ci -ignore=examples/*/*.go
+  - goveralls -coverprofile=coverage.out -service=travis-ci -ignore=examples/*/*.go,examples/*/*/*.go
 
 matrix:
   allow_failures:

--- a/example/golack/eventsapi/main.go
+++ b/example/golack/eventsapi/main.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"github.com/oklahomer/golack"
+	"github.com/oklahomer/golack/event"
+	"github.com/oklahomer/golack/eventsapi"
+	"github.com/oklahomer/golack/webapi"
+	"log"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+)
+
+func main() {
+	config := golack.NewConfig()
+	config.AppSecret = os.Getenv("APP_SECRET")
+	config.Token = os.Getenv("APP_TOKEN")
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	g := golack.New(config)
+	errChan := g.RunServer(ctx, &Receiver{client: g})
+
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
+
+	select {
+	case <-c:
+		fmt.Println("FINISH")
+		cancel()
+
+	case err := <-errChan:
+		fmt.Printf("ERROR: %s\n", err.Error())
+		cancel()
+	}
+}
+
+type Receiver struct {
+	client *golack.Golack
+}
+
+func (r *Receiver) Receive(wrapper *eventsapi.EventWrapper) {
+	switch typed := wrapper.Event.(type) {
+	case *event.MessageChannels:
+		// A message is sent to a public channel
+		log.Printf("Channel Message: %+v", typed)
+		echoMsg := EchoMessage(typed.Text)
+		if echoMsg == "" {
+			return
+		}
+
+		message := webapi.NewPostMessage(typed.ChannelID, echoMsg)
+		message.AsUser = true
+		log.Printf("Payload: %+v", message)
+		response, err := r.client.PostMessage(context.TODO(), message)
+		if err != nil {
+			log.Printf("Post error: %s", err.Error())
+			return
+		}
+
+		if !response.OK {
+			log.Printf("Response error: %s", response.Error)
+			return
+		}
+
+	case *event.MessageGroups:
+		// A message is sent to a group
+		log.Printf("Group Message: %+v", typed)
+
+	case *event.MessageIM:
+		// A message directly sent to the app
+		log.Printf("IM Message: %+v", typed)
+
+	default:
+		log.Printf("Event: %T, %+v", typed, typed)
+	}
+}
+
+var _ eventsapi.EventReceiver = (*Receiver)(nil)
+
+func EchoMessage(text string) string {
+	echoMsg := strings.TrimPrefix(text, ".echo ")
+	if echoMsg == text {
+		// Original text did not starts with echo command
+		return ""
+	}
+
+	return echoMsg
+}

--- a/example/golack/rtmapi/main.go
+++ b/example/golack/rtmapi/main.go
@@ -3,9 +3,8 @@ package main
 import (
 	"context"
 	"fmt"
+	"github.com/oklahomer/golack"
 	"github.com/oklahomer/golack/event"
-	"github.com/oklahomer/golack/rtmapi"
-	"github.com/oklahomer/golack/webapi"
 	"os"
 	"os/signal"
 	"syscall"
@@ -14,23 +13,13 @@ import (
 func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 
-	// Setup Web API client
-	config := webapi.NewConfig()
+	// Setup Golack client
+	config := golack.NewConfig()
 	config.Token = os.Getenv("APP_TOKEN")
-	client := webapi.NewClient(config)
+	client := golack.New(config)
 
-	// Retrieve RTM session information from Web API
-	rtmStart := &webapi.RTMStart{}
-	err := client.Get(ctx, "rtm.start", nil, rtmStart)
-	if err != nil {
-		panic(err)
-	}
-	if rtmStart.OK != true {
-		panic(fmt.Errorf("failed rtm.start request: %s", rtmStart.Error))
-	}
-
-	// Create WebSocket connection with the returned URL
-	conn, err := rtmapi.Connect(ctx, rtmStart.URL)
+	// Establish WebSocket connection
+	conn, err := client.ConnectRTM(ctx)
 	if err != nil {
 		panic(err)
 	}

--- a/golack.go
+++ b/golack.go
@@ -87,7 +87,8 @@ func (g *Golack) PostMessage(ctx context.Context, postMessage *webapi.PostMessag
 // ConnectRTM connects to Slack WebSocket server.
 func (g *Golack) ConnectRTM(ctx context.Context) (rtmapi.Connection, error) {
 	rtmStart := &webapi.RTMStart{}
-	if err := g.WebClient.Get(ctx, "rtm.start", nil, rtmStart); err != nil {
+	err := g.WebClient.Get(ctx, "rtm.start", nil, rtmStart)
+	if err != nil {
 		return nil, err
 	}
 

--- a/golack.go
+++ b/golack.go
@@ -3,6 +3,9 @@ package golack
 import (
 	"context"
 	"fmt"
+	"github.com/oklahomer/golack/eventsapi"
+	"golang.org/x/xerrors"
+	"net/http"
 	"net/url"
 	"time"
 
@@ -11,16 +14,20 @@ import (
 )
 
 type Config struct {
+	AppSecret      string        `json:"app_secret" yaml:"app_secret"`
 	Token          string        `json:"token" yaml:"token"`
+	ListenPort     int           `json:"listen_port" yaml:"listen_port"`
 	RequestTimeout time.Duration `json:"request_timeout" yaml:"request_timeout"`
 }
 
 // NewConfig returns initialized Config struct with default settings.
-// Token is empty at this point. Token and other settings can be set/updated by feeding this instance to json.Unmarshal/yaml.Unmarshal,
-// or assigning directly.
+// AppSecret and Token are empty at this point. They can be set/updated by feeding this instance to json.Unmarshal/yaml.Unmarshal
+// or by direct assignment.
 func NewConfig() *Config {
 	return &Config{
+		AppSecret:      "",
 		Token:          "",
+		ListenPort:     8080,
 		RequestTimeout: 3 * time.Second,
 	}
 }
@@ -34,47 +41,38 @@ type Option func(*Golack)
 
 func WithWebClient(wc WebClient) Option {
 	return func(g *Golack) {
-		g.webClient = wc
+		g.WebClient = wc
 	}
 }
 
 type Golack struct {
-	webClient WebClient
+	config    *Config
+	WebClient WebClient
 }
 
 func New(config *Config, options ...Option) *Golack {
 	g := &Golack{}
+	g.config = config
+
+	// Apply options to change specific behaviors
 	for _, opt := range options {
 		opt(g)
 	}
 
-	if g.webClient == nil {
-		apiConfig := &webapi.Config{
-			Token:          config.Token,
-			RequestTimeout: config.RequestTimeout,
-		}
-		g.webClient = webapi.NewClient(apiConfig)
+	// If WebClient is not set with Option, then built one with default settings
+	if g.WebClient == nil {
+		apiConfig := webapi.NewConfig()
+		apiConfig.Token = g.config.Token
+		apiConfig.RequestTimeout = g.config.RequestTimeout
+		g.WebClient = webapi.NewClient(apiConfig)
 	}
 
 	return g
 }
 
-func (g *Golack) StartRTMSession(ctx context.Context) (*webapi.RTMStart, error) {
-	rtmStart := &webapi.RTMStart{}
-	if err := g.webClient.Get(ctx, "rtm.start", nil, rtmStart); err != nil {
-		return nil, err
-	}
-
-	if rtmStart.OK != true {
-		return nil, fmt.Errorf("failed rtm.start request: %s", rtmStart.Error)
-	}
-
-	return rtmStart, nil
-}
-
 func (g *Golack) PostMessage(ctx context.Context, postMessage *webapi.PostMessage) (*webapi.APIResponse, error) {
 	response := &webapi.APIResponse{}
-	err := g.webClient.Post(ctx, "chat.postMessage", postMessage.ToURLValues(), response)
+	err := g.WebClient.Post(ctx, "chat.postMessage", postMessage.ToURLValues(), response)
 	if err != nil {
 		return nil, err
 	}
@@ -86,7 +84,47 @@ func (g *Golack) PostMessage(ctx context.Context, postMessage *webapi.PostMessag
 	return response, nil
 }
 
-// Connect connects to Slack WebSocket server.
-func (g *Golack) ConnectRTM(ctx context.Context, url string) (rtmapi.Connection, error) {
-	return rtmapi.Connect(ctx, url)
+// ConnectRTM connects to Slack WebSocket server.
+func (g *Golack) ConnectRTM(ctx context.Context) (rtmapi.Connection, error) {
+	rtmStart := &webapi.RTMStart{}
+	if err := g.WebClient.Get(ctx, "rtm.start", nil, rtmStart); err != nil {
+		return nil, err
+	}
+
+	if rtmStart.OK != true {
+		return nil, fmt.Errorf("failed rtm.start request: %s", rtmStart.Error)
+	}
+
+	return rtmapi.Connect(ctx, rtmStart.URL)
+}
+
+func (g *Golack) RunServer(ctx context.Context, receiver eventsapi.EventReceiver) <-chan error {
+	errChan := make(chan error, 1)
+
+	// Setup a request validator
+	// For better security, this checks each request's signature
+	appSecret := g.config.AppSecret
+	if appSecret == "" {
+		errChan <- xerrors.New("application secret is not set")
+		return errChan
+	}
+	optValidator := eventsapi.WithRequestValidator(&eventsapi.SignatureValidator{Secret: appSecret})
+
+	// Setup server and run it
+	srv := &http.Server{
+		Addr:    fmt.Sprintf(":%d", g.config.ListenPort),
+		Handler: eventsapi.SetupHandler(receiver, optValidator),
+	}
+	go func() {
+		errChan <- srv.ListenAndServe()
+	}()
+
+	// Shutdown the server
+	go func() {
+		<-ctx.Done()
+		//noinspection ALL
+		srv.Shutdown(ctx)
+	}()
+
+	return errChan
 }

--- a/golack_test.go
+++ b/golack_test.go
@@ -27,7 +27,7 @@ func TestWithWebClient(t *testing.T) {
 
 	option(golack)
 
-	if golack.webClient != webClient {
+	if golack.WebClient != webClient {
 		t.Errorf("Specified WebClient is not set.")
 	}
 }
@@ -47,34 +47,6 @@ func TestNew(t *testing.T) {
 	}
 }
 
-func TestGolack_StartRTMSession(t *testing.T) {
-	webClient := &DummyWebClient{
-		GetFunc: func(_ context.Context, slackMethod string, _ *url.Values, intf interface{}) error {
-			if slackMethod != "rtm.start" {
-				t.Errorf("Requesting path is not correct: %s.", slackMethod)
-			}
-			start := intf.(*webapi.RTMStart)
-			start.APIResponse = webapi.APIResponse{OK: true}
-			start.URL = "https://localhost/foo"
-			start.Self = nil
-			return nil
-		},
-	}
-	golack := &Golack{
-		webClient: webClient,
-	}
-
-	rtmStart, err := golack.StartRTMSession(context.TODO())
-
-	if err != nil {
-		t.Errorf("something went wrong. %#v", err)
-	}
-
-	if rtmStart.URL != "https://localhost/foo" {
-		t.Errorf("URL is not returned properly. %#v", rtmStart)
-	}
-}
-
 func TestGolack_PostMessage(t *testing.T) {
 	webClient := &DummyWebClient{
 		PostFunc: func(ctx context.Context, slackMethod string, bodyParam url.Values, intf interface{}) error {
@@ -87,7 +59,7 @@ func TestGolack_PostMessage(t *testing.T) {
 
 	postMessage := webapi.NewPostMessage("channel", "my message")
 	golack := &Golack{
-		webClient: webClient,
+		WebClient: webClient,
 	}
 	response, err := golack.PostMessage(context.TODO(), postMessage)
 

--- a/golack_test.go
+++ b/golack_test.go
@@ -24,6 +24,21 @@ func (wc *DummyWebClient) Post(ctx context.Context, slackMethod string, bodyPara
 	return wc.PostFunc(ctx, slackMethod, bodyParam, intf)
 }
 
+func TestNewConfig(t *testing.T) {
+	config := NewConfig()
+	if config == nil {
+		t.Fatal("Returned *Config is nil.")
+	}
+
+	if config.RequestTimeout == 0 {
+		t.Error("Default timeout is not set.")
+	}
+
+	if config.ListenPort == 0 {
+		t.Error("Default listen port is not set.")
+	}
+}
+
 func TestWithWebClient(t *testing.T) {
 	webClient := &DummyWebClient{}
 	option := WithWebClient(webClient)

--- a/testutil/websocket.go
+++ b/testutil/websocket.go
@@ -1,0 +1,64 @@
+package testutil
+
+import (
+	"fmt"
+	"github.com/gorilla/websocket"
+	"net"
+	"net/http"
+	"net/http/httptest"
+)
+
+type Pong struct {
+	Type    string `json:"type"`
+	ReplyTo uint   `json:"reply_to"`
+}
+
+func echoServer(w http.ResponseWriter, r *http.Request) {
+	upgrader := websocket.Upgrader{}
+	c, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		panic(fmt.Errorf("failed to upgrade protocol: %s", err.Error()))
+	}
+	defer c.Close()
+
+	for {
+		mt, message, err := c.ReadMessage()
+		if err != nil {
+			_, ok := err.(*websocket.CloseError)
+			if !ok {
+				panic(fmt.Errorf("failed to receive message: %s", err.Error()))
+			}
+			break
+		}
+		err = c.WriteMessage(mt, message)
+		if err != nil {
+			panic(fmt.Errorf("failed to send message. type: %d. error: %s", mt, err.Error()))
+		}
+	}
+}
+
+func pingServer(w http.ResponseWriter, r *http.Request) {
+	upgrader := websocket.Upgrader{}
+	c, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		panic(fmt.Errorf("failed to upgrade protocol: %s", err.Error()))
+	}
+	defer c.Close()
+
+	res := &Pong{}
+	c.WriteJSON(res)
+}
+
+func RunWithWebSocket(fnc func(addr net.Addr)) {
+	// Setup server
+	mux := http.NewServeMux()
+	mux.HandleFunc("/echo", echoServer)
+	mux.HandleFunc("/ping", pingServer)
+	server := httptest.NewServer(mux)
+
+	// Close after test
+	defer server.Close()
+
+	// Run test with WebSocket server
+	fnc(server.Listener.Addr())
+}

--- a/webapi/client.go
+++ b/webapi/client.go
@@ -16,8 +16,15 @@ const (
 )
 
 type Config struct {
-	Token          string
-	RequestTimeout time.Duration
+	Token          string        `json:"token" yaml:"token"`
+	RequestTimeout time.Duration `json:"request_timeout" yaml:"request_timeout"`
+}
+
+func NewConfig() *Config {
+	return &Config{
+		Token:          "",
+		RequestTimeout: 3 * time.Second,
+	}
 }
 
 type ClientOption func(*Client)


### PR DESCRIPTION
With the changes made by #20, golack now interacts with Events API along with RTM and Web API. Currently, each sub-package such as `rtmapi` and `webapi` provides a relatively lower-leveled interface for each API while `golack` provides a higher-level interface. Interface for Events API should also be defined.
When this p-r is merged, this project is to provide the below features:

- [x] Higher-level interface for each API via `golack` client
- [x] Lower level interface via each sub-package

With such features, golack itself works somewhat as a "facade" to easier interact with Slack while each sub-package provides more customizable interfaces.