### PR TITLE
Enable posting with application/json

### DIFF
--- a/golack.go
+++ b/golack.go
@@ -42,8 +42,9 @@ func NewConfig() *Config {
 
 // WebClient defines an interface that abstracts the webapi.Client.
 type WebClient interface {
-	Get(ctx context.Context, slackMethod string, queryParams url.Values, intf interface{}) error
-	Post(ctx context.Context, slackMethod string, bodyParam url.Values, intf interface{}) error
+	Get(ctx context.Context, slackMethod string, queryParams url.Values, response interface{}) error
+	Post(ctx context.Context, slackMethod string, payload url.Values, response interface{}) error
+	PostJSON(ctx context.Context, slackMethod string, payload interface{}, response interface{}) error
 }
 
 type Option func(*Golack)
@@ -89,7 +90,7 @@ func New(config *Config, options ...Option) *Golack {
 // See https://api.slack.com/methods/chat.postMessage for official document.
 func (g *Golack) PostMessage(ctx context.Context, postMessage *webapi.PostMessage) (*webapi.APIResponse, error) {
 	response := &webapi.APIResponse{}
-	err := g.WebClient.Post(ctx, "chat.postMessage", postMessage.ToURLValues(), response)
+	err := g.WebClient.PostJSON(ctx, "chat.postMessage", postMessage, response)
 	if err != nil {
 		return nil, err
 	}

--- a/golack_test.go
+++ b/golack_test.go
@@ -16,16 +16,21 @@ import (
 )
 
 type DummyWebClient struct {
-	GetFunc  func(ctx context.Context, slackMethod string, queryParams url.Values, intf interface{}) error
-	PostFunc func(ctx context.Context, slackMethod string, bodyParam url.Values, intf interface{}) error
+	GetFunc      func(ctx context.Context, slackMethod string, queryParams url.Values, response interface{}) error
+	PostFunc     func(ctx context.Context, slackMethod string, payload url.Values, response interface{}) error
+	PostJSONFunc func(ctx context.Context, slackMethod string, payload interface{}, response interface{}) error
 }
 
-func (wc *DummyWebClient) Get(ctx context.Context, slackMethod string, queryParams url.Values, intf interface{}) error {
-	return wc.GetFunc(ctx, slackMethod, queryParams, intf)
+func (wc *DummyWebClient) Get(ctx context.Context, slackMethod string, queryParams url.Values, response interface{}) error {
+	return wc.GetFunc(ctx, slackMethod, queryParams, response)
 }
 
-func (wc *DummyWebClient) Post(ctx context.Context, slackMethod string, bodyParam url.Values, intf interface{}) error {
-	return wc.PostFunc(ctx, slackMethod, bodyParam, intf)
+func (wc *DummyWebClient) Post(ctx context.Context, slackMethod string, payload url.Values, response interface{}) error {
+	return wc.PostFunc(ctx, slackMethod, payload, response)
+}
+
+func (wc *DummyWebClient) PostJSON(ctx context.Context, slackMethod string, payload interface{}, response interface{}) error {
+	return wc.PostJSONFunc(ctx, slackMethod, payload, response)
 }
 
 type DummyReceiver struct {
@@ -82,7 +87,7 @@ func TestGolack_PostMessage(t *testing.T) {
 	t.Run("Web API returns error status", func(t *testing.T) {
 		expectedErr := xerrors.New("DUMMY")
 		webClient := &DummyWebClient{
-			PostFunc: func(_ context.Context, _ string, _ url.Values, _ interface{}) error {
+			PostJSONFunc: func(_ context.Context, _ string, _ interface{}, _ interface{}) error {
 				return expectedErr
 			},
 		}
@@ -101,10 +106,10 @@ func TestGolack_PostMessage(t *testing.T) {
 
 	t.Run("Web API returns error response", func(t *testing.T) {
 		webClient := &DummyWebClient{
-			PostFunc: func(_ context.Context, _ string, _ url.Values, intf interface{}) error {
-				response := intf.(*webapi.APIResponse)
-				response.OK = false
-				response.Error = "some error"
+			PostJSONFunc: func(_ context.Context, _ string, _ interface{}, response interface{}) error {
+				resp := response.(*webapi.APIResponse)
+				resp.OK = false
+				resp.Error = "some error"
 				return nil
 			},
 		}
@@ -120,10 +125,15 @@ func TestGolack_PostMessage(t *testing.T) {
 
 	t.Run("success", func(t *testing.T) {
 		webClient := &DummyWebClient{
-			PostFunc: func(_ context.Context, _ string, _ url.Values, intf interface{}) error {
-				response := intf.(*webapi.APIResponse)
-				response.OK = true
-				response.Error = ""
+			PostJSONFunc: func(_ context.Context, _ string, payload interface{}, response interface{}) error {
+				message := payload.(*webapi.PostMessage)
+				if message.ChannelID != "channel" && message.Text != "my message" {
+					t.Errorf("Expected payload is not passed: %+v", message)
+				}
+
+				resp := response.(*webapi.APIResponse)
+				resp.OK = true
+				resp.Error = ""
 				return nil
 			},
 		}
@@ -167,10 +177,10 @@ func TestGolack_ConnectRTM(t *testing.T) {
 
 	t.Run("Web API returns error response", func(t *testing.T) {
 		webClient := &DummyWebClient{
-			GetFunc: func(_ context.Context, _ string, _ url.Values, intf interface{}) error {
-				response := intf.(*webapi.RTMStart)
-				response.OK = false
-				response.Error = "some error"
+			GetFunc: func(_ context.Context, _ string, _ url.Values, response interface{}) error {
+				resp := response.(*webapi.RTMStart)
+				resp.OK = false
+				resp.Error = "some error"
 				return nil
 			},
 		}
@@ -187,11 +197,11 @@ func TestGolack_ConnectRTM(t *testing.T) {
 	t.Run("connect WebSocket server", func(t *testing.T) {
 		testutil.RunWithWebSocket(func(addr net.Addr) {
 			webClient := &DummyWebClient{
-				GetFunc: func(_ context.Context, _ string, _ url.Values, intf interface{}) error {
-					response := intf.(*webapi.RTMStart)
-					response.OK = true
-					response.URL = fmt.Sprintf("ws://%s%s", addr, "/ping")
-					response.Error = ""
+				GetFunc: func(_ context.Context, _ string, _ url.Values, response interface{}) error {
+					resp := response.(*webapi.RTMStart)
+					resp.OK = true
+					resp.URL = fmt.Sprintf("ws://%s%s", addr, "/ping")
+					resp.Error = ""
 					return nil
 				},
 			}

--- a/webapi/client.go
+++ b/webapi/client.go
@@ -158,7 +158,6 @@ func (client *Client) PostJSON(ctx context.Context, slackMethod string, payload 
 	if err != nil {
 		return err
 	}
-	fmt.Printf("%s\n", string(body))
 	req, err := http.NewRequest("POST", endpoint.String(), bytes.NewReader(body))
 	if err != nil {
 		return err

--- a/webapi/request.go
+++ b/webapi/request.go
@@ -45,19 +45,19 @@ type MessageAttachment struct {
 // PostMessage is a payload to be sent with chat.postMessage method.
 // See https://api.slack.com/methods/chat.postMessage
 type PostMessage struct {
-	ChannelID       event.ChannelID
-	Text            string
-	Parse           ParseMode
-	LinkNames       int
-	Attachments     []*MessageAttachment
-	UnfurlLinks     bool
-	UnfurlMedia     bool
-	UserName        string
-	AsUser          bool
-	IconURL         string
-	IconEmoji       string
-	ReplyBroadcast  bool
-	ThreadTimeStamp string
+	ChannelID       event.ChannelID      `json:"channel"`
+	Text            string               `json:"text"`
+	Parse           ParseMode            `json:"parse,omitempty"`
+	LinkNames       int                  `json:"link_names,omitempty"`
+	Attachments     []*MessageAttachment `json:"attachments,omitempty"`
+	UnfurlLinks     bool                 `json:"unfurl_links,omitempty"`
+	UnfurlMedia     bool                 `json:"unfurl_media,omitempty"`
+	UserName        string               `json:"username,omitempty"`
+	AsUser          bool                 `json:"as_user,omitempty"`
+	IconURL         string               `json:"icon_url,omitempty"`
+	IconEmoji       string               `json:"icon_emoji,omitempty"`
+	ReplyBroadcast  bool                 `json:"reply_broadcast,omitempty"`
+	ThreadTimeStamp string               `json:"thread_ts,omitempty"`
 }
 
 // WithAttachments sets/overrides attachments parameter for current PostMessage.


### PR DESCRIPTION
Now [some methods](https://api.slack.com/web#methods_supporting_json) receive [JSON formated payload](https://api.slack.com/web#json-encoded_bodies) with `application/json` Content-Type header. It should be easier to handle payload in such a way than doing so with `application/x-www-form-urlencoded` type especially when the payload has a complicated structure. As a matter of fact, [PostMessage.ToURLValues](https://github.com/oklahomer/golack/blob/75ad9b2a4ace063b033241c514458789056bd874/webapi/request.go#L115-L144) requires a lot of effort to build a request.
This p-r adds a new method to post payload with `application/json` Content-Type header.