### PR TITLE
Support block layouts on outgoing message

### DIFF
--- a/event/block.go
+++ b/event/block.go
@@ -62,9 +62,23 @@ func (b *block) BlockType() string {
 	return b.Type
 }
 
+func (b *block) WithBlockID(blockID BlockID) *block {
+	b.BlockID = blockID
+	return b
+}
+
 type ActionsBlock struct {
 	block
 	Elements []BlockElement `json:"elements"`
+}
+
+func NewActionsBlock(elements []BlockElement) *ActionsBlock {
+	return &ActionsBlock{
+		block: block{
+			Type: "actions",
+		},
+		Elements: elements,
+	}
 }
 
 func (ab *ActionsBlock) UnmarshalJSON(b []byte) error {
@@ -98,6 +112,15 @@ type ContextBlock struct {
 	Elements []BlockElement `json:"elements"`
 }
 
+func NewContextBlock(elements []BlockElement) *ContextBlock {
+	return &ContextBlock{
+		block: block{
+			Type: "context",
+		},
+		Elements: elements,
+	}
+}
+
 func (cb *ContextBlock) UnmarshalJSON(b []byte) error {
 	type alias ContextBlock
 	t := &struct {
@@ -128,10 +151,28 @@ type DividerBlock struct {
 	block
 }
 
+func NewDividerBlock() *DividerBlock {
+	return &DividerBlock{
+		block: block{
+			Type: "divider",
+		},
+	}
+}
+
 type FileBlock struct {
 	block
 	ExternalID string `json:"external_id"`
 	Source     string `json:"source"`
+}
+
+func NewRemoteFileBlock(externalID string) *FileBlock {
+	return &FileBlock{
+		block: block{
+			Type: "file",
+		},
+		ExternalID: externalID,
+		Source:     "remote",
+	}
 }
 
 type ImageBlock struct {
@@ -141,12 +182,47 @@ type ImageBlock struct {
 	Title    *TextCompositionObject `json:"title,omitempty"`
 }
 
+func (ib *ImageBlock) WithTitle(title *TextCompositionObject) *ImageBlock {
+	ib.Title = title
+	return ib
+}
+
+func NewImageBlock(imageURL string, altText string) *ImageBlock {
+	return &ImageBlock{
+		block: block{
+			Type: "image",
+		},
+		ImageURL: imageURL,
+		AltText:  altText,
+	}
+}
+
 type InputBlock struct {
 	block
 	Label    *TextCompositionObject `json:"label"`
 	Element  BlockElement           `json:"element"`
 	Hint     *TextCompositionObject `json:"hint,omitempty"`
 	Optional bool                   `json:"optional,omitempty"`
+}
+
+func (ib *InputBlock) WithHint(hint *TextCompositionObject) *InputBlock {
+	ib.Hint = hint
+	return ib
+}
+
+func (ib *InputBlock) WithOptional(flg bool) *InputBlock {
+	ib.Optional = flg
+	return ib
+}
+
+func NewInputBlock(label *TextCompositionObject, element BlockElement) *InputBlock {
+	return &InputBlock{
+		block: block{
+			Type: "input",
+		},
+		Label:   label,
+		Element: element,
+	}
 }
 
 func (ib *InputBlock) UnmarshalJSON(b []byte) error {
@@ -176,8 +252,27 @@ func (ib *InputBlock) UnmarshalJSON(b []byte) error {
 type SectionBlock struct {
 	block
 	Text      *TextCompositionObject   `json:"text"`
-	Fields    []*TextCompositionObject `json:"fields"`
-	Accessory BlockElement             `json:"accessory"`
+	Fields    []*TextCompositionObject `json:"fields,omitempty"`
+	Accessory BlockElement             `json:"accessory,omitempty"`
+}
+
+func (sb *SectionBlock) WithFields(fields []*TextCompositionObject) *SectionBlock {
+	sb.Fields = fields
+	return sb
+}
+
+func (sb *SectionBlock) WithAccessory(accessory BlockElement) *SectionBlock {
+	sb.Accessory = accessory
+	return sb
+}
+
+func NewSectionBlock(text *TextCompositionObject) *SectionBlock {
+	return &SectionBlock{
+		block: block{
+			Type: "section",
+		},
+		Text: text,
+	}
 }
 
 func (sb *SectionBlock) UnmarshalJSON(b []byte) error {

--- a/event/block_element.go
+++ b/event/block_element.go
@@ -28,10 +28,10 @@ func UnmarshalBlockElement(input json.RawMessage) (BlockElement, error) {
 		typed = &ImageBlockElement{}
 
 	case "multi_static_select":
-		typed = &MultiStaticSelectBLockElement{}
+		typed = &MultiStaticSelectBlockElement{}
 
 	case "multi_external_select":
-		typed = &MultiExternalSelectBLockElement{}
+		typed = &MultiExternalSelectBlockElement{}
 
 	case "multi_users_select":
 		typed = &MultiUsersSelectBlockElement{}
@@ -104,12 +104,62 @@ type ButtonBlockElement struct {
 	Confirm  *ConfirmationDialogObject `json:"confirm,omitempty"`
 }
 
+func (b *ButtonBlockElement) WithURL(url string) *ButtonBlockElement {
+	b.URL = url
+	return b
+}
+
+func (b *ButtonBlockElement) WithValue(value string) *ButtonBlockElement {
+	b.Value = value
+	return b
+}
+
+func (b *ButtonBlockElement) WithStyle(style Style) *ButtonBlockElement {
+	b.Style = style
+	return b
+}
+
+func (b *ButtonBlockElement) WithConfirm(confirm *ConfirmationDialogObject) *ButtonBlockElement {
+	b.Confirm = confirm
+	return b
+}
+
+func NewButtonBlockElement(text *TextCompositionObject, actionID ActionID) *ButtonBlockElement {
+	return &ButtonBlockElement{
+		blockElement: blockElement{
+			Type: "button",
+		},
+		Text:     text,
+		ActionID: actionID,
+	}
+}
+
 type CheckboxBlockElement struct {
 	blockElement
 	ActionID       ActionID                  `json:"action_id"`
 	Options        []*OptionObject           `json:"options"`
 	InitialOptions []*OptionObject           `json:"initial_options,omitempty"`
 	Confirm        *ConfirmationDialogObject `json:"confirm,omitempty"`
+}
+
+func (c *CheckboxBlockElement) WithInitialOptions(options []*OptionObject) *CheckboxBlockElement {
+	c.InitialOptions = options
+	return c
+}
+
+func (c *CheckboxBlockElement) WithConfirm(confirm *ConfirmationDialogObject) *CheckboxBlockElement {
+	c.Confirm = confirm
+	return c
+}
+
+func NewCheckboxBlockElement(actionID ActionID, options []*OptionObject) *CheckboxBlockElement {
+	return &CheckboxBlockElement{
+		blockElement: blockElement{
+			Type: "checkboxes",
+		},
+		ActionID: actionID,
+		Options:  options,
+	}
 }
 
 type DatePickerBlockElement struct {
@@ -120,28 +170,93 @@ type DatePickerBlockElement struct {
 	Confirm     *ConfirmationDialogObject `json:"confirm,omitempty"`
 }
 
+func (d *DatePickerBlockElement) WithPlaceHolder(placeholder *TextCompositionObject) *DatePickerBlockElement {
+	d.PlaceHolder = placeholder
+	return d
+}
+
+func (d *DatePickerBlockElement) WithInitialDate(date string) *DatePickerBlockElement {
+	d.InitialDate = date
+	return d
+}
+
+func (d *DatePickerBlockElement) WithConfirm(confirm *ConfirmationDialogObject) *DatePickerBlockElement {
+	d.Confirm = confirm
+	return d
+}
+
+func NewDatePickerBlockElement(actionID ActionID) *DatePickerBlockElement {
+	return &DatePickerBlockElement{
+		blockElement: blockElement{
+			Type: "datepicker",
+		},
+		ActionID: actionID,
+	}
+}
+
 type ImageBlockElement struct {
 	blockElement
 	ImageURL string `json:"image_url"`
 	AltText  string `json:"alt_text"`
 }
 
-// MultiStaticSelectBLockElement is a Multi-select menu with static options.
+func NewImageBlockElement(imageURL string, altText string) *ImageBlockElement {
+	return &ImageBlockElement{
+		blockElement: blockElement{
+			Type: "image",
+		},
+		ImageURL: imageURL,
+		AltText:  altText,
+	}
+}
+
+// MultiStaticSelectBlockElement is a Multi-select menu with static options.
 // This has a type of "multi_static_select."
-type MultiStaticSelectBLockElement struct {
+type MultiStaticSelectBlockElement struct {
 	blockElement
 	Placeholder      *TextCompositionObject    `json:"placeholder"`
 	ActionID         ActionID                  `json:"action_id"`
 	Options          []*OptionObject           `json:"options"`
-	OptionsGroups    []*OptionGroupObject      `json:"option_groups,omitempty"`
+	OptionGroups     []*OptionGroupObject      `json:"option_groups,omitempty"`
 	InitialOptions   []*OptionObject           `json:"initial_options,omitempty"`
 	Confirm          *ConfirmationDialogObject `json:"confirm,omitempty"`
 	MaxSelectedItems int                       `json:"max_selected_items,omitempty"`
 }
 
-// MultiExternalSelectBLockElement is a Multi-select menu with external data source.
+func (m *MultiStaticSelectBlockElement) WithOptionsGroups(optionGroups []*OptionGroupObject) *MultiStaticSelectBlockElement {
+	m.OptionGroups = optionGroups
+	return m
+}
+
+func (m *MultiStaticSelectBlockElement) WithInitialOptions(options []*OptionObject) *MultiStaticSelectBlockElement {
+	m.InitialOptions = options
+	return m
+}
+
+func (m *MultiStaticSelectBlockElement) WithConfirm(confirm *ConfirmationDialogObject) *MultiStaticSelectBlockElement {
+	m.Confirm = confirm
+	return m
+}
+
+func (m *MultiStaticSelectBlockElement) WithMaxSelectedItems(max int) *MultiStaticSelectBlockElement {
+	m.MaxSelectedItems = max
+	return m
+}
+
+func NewMultiStaticSelectBlockElement(placeholder *TextCompositionObject, actionID ActionID, options []*OptionObject) *MultiStaticSelectBlockElement {
+	return &MultiStaticSelectBlockElement{
+		blockElement: blockElement{
+			Type: "multi_static_select",
+		},
+		Placeholder: placeholder,
+		ActionID:    actionID,
+		Options:     options,
+	}
+}
+
+// MultiExternalSelectBlockElement is a Multi-select menu with external data source.
 // This has a type of "multi_external_select."
-type MultiExternalSelectBLockElement struct {
+type MultiExternalSelectBlockElement struct {
 	blockElement
 	Placeholder      *TextCompositionObject    `json:"placeholder"`
 	ActionID         ActionID                  `json:"action_id"`
@@ -149,6 +264,36 @@ type MultiExternalSelectBLockElement struct {
 	InitialOptions   []*OptionObject           `json:"initial_options,omitempty"`
 	Confirm          *ConfirmationDialogObject `json:"confirm,omitempty"`
 	MaxSelectedItems int                       `json:"max_selected_items,omitempty"`
+}
+
+func (m *MultiExternalSelectBlockElement) WithMinQueryLength(min int) *MultiExternalSelectBlockElement {
+	m.MinQueryLength = min
+	return m
+}
+
+func (m *MultiExternalSelectBlockElement) WithInitialOptions(options []*OptionObject) *MultiExternalSelectBlockElement {
+	m.InitialOptions = options
+	return m
+}
+
+func (m *MultiExternalSelectBlockElement) WithConfirm(confirm *ConfirmationDialogObject) *MultiExternalSelectBlockElement {
+	m.Confirm = confirm
+	return m
+}
+
+func (m *MultiExternalSelectBlockElement) WithMaxSelectedItems(max int) *MultiExternalSelectBlockElement {
+	m.MaxSelectedItems = max
+	return m
+}
+
+func NewMultiExternalSelectBlockElement(placeholder *TextCompositionObject, actionID ActionID) *MultiExternalSelectBlockElement {
+	return &MultiExternalSelectBlockElement{
+		blockElement: blockElement{
+			Type: "multi_external_select",
+		},
+		Placeholder: placeholder,
+		ActionID:    actionID,
+	}
 }
 
 // MultiUsersSelectBlockElement is a Multi-select menu with a list of Slack users visible to the current user.
@@ -160,6 +305,31 @@ type MultiUsersSelectBlockElement struct {
 	InitialUserIDs   []UserID                  `json:"users,omitempty"`
 	Confirm          *ConfirmationDialogObject `json:"confirm,omitempty"`
 	MaxSelectedItems int                       `json:"max_selected_items,omitempty"`
+}
+
+func (m *MultiUsersSelectBlockElement) WithInitialUserIDs(ids []UserID) *MultiUsersSelectBlockElement {
+	m.InitialUserIDs = ids
+	return m
+}
+
+func (m *MultiUsersSelectBlockElement) WithConfirm(confirm *ConfirmationDialogObject) *MultiUsersSelectBlockElement {
+	m.Confirm = confirm
+	return m
+}
+
+func (m *MultiUsersSelectBlockElement) WithMaxSelectedItems(max int) *MultiUsersSelectBlockElement {
+	m.MaxSelectedItems = max
+	return m
+}
+
+func NewMultiUsersSelectBlockElement(placeholder *TextCompositionObject, actionID ActionID) *MultiUsersSelectBlockElement {
+	return &MultiUsersSelectBlockElement{
+		blockElement: blockElement{
+			Type: "multi_users_select",
+		},
+		Placeholder: placeholder,
+		ActionID:    actionID,
+	}
 }
 
 // MultiConversationsSelectBlockElement is a Multi-select menu with a list of public and private channels.
@@ -175,6 +345,41 @@ type MultiConversationsSelectBlockElement struct {
 	Filter                       *FilterObject             `json:"filter,omitempty"`
 }
 
+func (m *MultiConversationsSelectBlockElement) WithInitialConversations(conversations []string) *MultiConversationsSelectBlockElement {
+	m.InitialConversations = conversations
+	return m
+}
+
+func (m *MultiConversationsSelectBlockElement) WithDefaultToCurrentConversation(flg bool) *MultiConversationsSelectBlockElement {
+	m.DefaultToCurrentConversation = flg
+	return m
+}
+
+func (m *MultiConversationsSelectBlockElement) WithConfirm(confirm *ConfirmationDialogObject) *MultiConversationsSelectBlockElement {
+	m.Confirm = confirm
+	return m
+}
+
+func (m *MultiConversationsSelectBlockElement) WithMaxSelectedItems(max int) *MultiConversationsSelectBlockElement {
+	m.MaxSelectedItems = max
+	return m
+}
+
+func (m *MultiConversationsSelectBlockElement) WithFilter(filter *FilterObject) *MultiConversationsSelectBlockElement {
+	m.Filter = filter
+	return m
+}
+
+func NewMultiConversationsSelectBlockElement(placeholder *TextCompositionObject, actionID ActionID) *MultiConversationsSelectBlockElement {
+	return &MultiConversationsSelectBlockElement{
+		blockElement: blockElement{
+			Type: "multi_conversations_select",
+		},
+		Placeholder: placeholder,
+		ActionID:    actionID,
+	}
+}
+
 // MultiChannelsSelectBlockElement is a Multi-select menu with a list of public channels visible to the current user.
 // This has a type of "multi_channels_select."
 type MultiChannelsSelectBlockElement struct {
@@ -186,11 +391,47 @@ type MultiChannelsSelectBlockElement struct {
 	MaxSelectedItems  int                       `json:"max_selected_items,omitempty"`
 }
 
+func (m *MultiChannelsSelectBlockElement) WithInitialChannelIDs(ids []ChannelID) *MultiChannelsSelectBlockElement {
+	m.InitialChannelIDs = ids
+	return m
+}
+
+func (m *MultiChannelsSelectBlockElement) WithConfirm(confirm *ConfirmationDialogObject) *MultiChannelsSelectBlockElement {
+	m.Confirm = confirm
+	return m
+}
+
+func (m *MultiChannelsSelectBlockElement) WithMaxSelectedItems(max int) *MultiChannelsSelectBlockElement {
+	m.MaxSelectedItems = max
+	return m
+}
+
+func NewMultiChannelsSelectBlockElement(placeholder *TextCompositionObject, actionID ActionID) *MultiChannelsSelectBlockElement {
+	return &MultiChannelsSelectBlockElement{
+		blockElement: blockElement{
+			Type: "multi_channels_select",
+		},
+		Placeholder: placeholder,
+		ActionID:    actionID,
+	}
+}
+
 type OverflowBlockElement struct {
 	blockElement
 	ActionID ActionID                  `json:"action_id"`
 	Options  []*OptionObject           `json:"options"`
 	Confirm  *ConfirmationDialogObject `json:"confirm"`
+}
+
+func NewOverflowBlockElement(actionID ActionID, options []*OptionObject, confirm *ConfirmationDialogObject) *OverflowBlockElement {
+	return &OverflowBlockElement{
+		blockElement: blockElement{
+			Type: "overflow",
+		},
+		ActionID: actionID,
+		Options:  options,
+		Confirm:  confirm,
+	}
 }
 
 type PlainTextInputBlockElement struct {
@@ -203,12 +444,66 @@ type PlainTextInputBlockElement struct {
 	MaxLength    int                    `json:"max_length,omitempty"`
 }
 
+func (p *PlainTextInputBlockElement) WithPlaceholder(placeholder *TextCompositionObject) *PlainTextInputBlockElement {
+	p.Placeholder = placeholder
+	return p
+}
+
+func (p *PlainTextInputBlockElement) WithInitialValue(initialValue string) *PlainTextInputBlockElement {
+	p.InitialValue = initialValue
+	return p
+}
+
+func (p *PlainTextInputBlockElement) WithMultiline(flg bool) *PlainTextInputBlockElement {
+	p.Multiline = flg
+	return p
+}
+
+func (p *PlainTextInputBlockElement) WithMinLength(min int) *PlainTextInputBlockElement {
+	p.MinLength = min
+	return p
+}
+
+func (p *PlainTextInputBlockElement) WithMaxLength(max int) *PlainTextInputBlockElement {
+	p.MaxLength = max
+	return p
+}
+
+func NewPlainTextInputBlockElement(actionID ActionID) *PlainTextInputBlockElement {
+	return &PlainTextInputBlockElement{
+		blockElement: blockElement{
+			Type: "plain_text_input",
+		},
+		ActionID: actionID,
+	}
+}
+
 type RadioButtonGroupBlockElement struct {
 	blockElement
 	ActionID      ActionID                  `json:"action_id"`
 	Options       []*OptionObject           `json:"options"`
 	InitialOption *OptionObject             `json:"initial_option,omitempty"`
 	Confirm       *ConfirmationDialogObject `json:"confirm,omitempty"`
+}
+
+func (r *RadioButtonGroupBlockElement) WithInitialOption(option *OptionObject) *RadioButtonGroupBlockElement {
+	r.InitialOption = option
+	return r
+}
+
+func (r *RadioButtonGroupBlockElement) WithConfirm(confirm *ConfirmationDialogObject) *RadioButtonGroupBlockElement {
+	r.Confirm = confirm
+	return r
+}
+
+func NewRadioButtonGroupBlockElement(actionID ActionID, options []*OptionObject) *RadioButtonGroupBlockElement {
+	return &RadioButtonGroupBlockElement{
+		blockElement: blockElement{
+			Type: "radio_buttons",
+		},
+		ActionID: actionID,
+		Options:  options,
+	}
 }
 
 // StaticSelectBlockElement is a Select menu element with a static list of options.
@@ -223,6 +518,32 @@ type StaticSelectBlockElement struct {
 	Confirm       *ConfirmationDialogObject `json:"confirm,omitempty"`
 }
 
+func (s *StaticSelectBlockElement) WithOptionGroups(optionGroups []*OptionGroupObject) *StaticSelectBlockElement {
+	s.OptionGroups = optionGroups
+	return s
+}
+
+func (s *StaticSelectBlockElement) WithInitialOption(option *OptionObject) *StaticSelectBlockElement {
+	s.InitialOption = option
+	return s
+}
+
+func (s *StaticSelectBlockElement) WithConfirm(confirm *ConfirmationDialogObject) *StaticSelectBlockElement {
+	s.Confirm = confirm
+	return s
+}
+
+func NewStaticSelectBlockElement(placeholder *TextCompositionObject, actionID ActionID, options []*OptionObject) *StaticSelectBlockElement {
+	return &StaticSelectBlockElement{
+		blockElement: blockElement{
+			Type: "static_select",
+		},
+		Placeholder: placeholder,
+		ActionID:    actionID,
+		Options:     options,
+	}
+}
+
 // ExternalSelectBlockElement is a Select menu element with external data source.
 // This has a type of "external_select."
 type ExternalSelectBlockElement struct {
@@ -234,6 +555,31 @@ type ExternalSelectBlockElement struct {
 	Confirm        *ConfirmationDialogObject `json:"confirm,omitempty"`
 }
 
+func (e *ExternalSelectBlockElement) WithInitialOption(option *OptionObject) *ExternalSelectBlockElement {
+	e.InitialOption = option
+	return e
+}
+
+func (e *ExternalSelectBlockElement) WithMinQueryLength(min int) *ExternalSelectBlockElement {
+	e.MinQueryLength = min
+	return e
+}
+
+func (e *ExternalSelectBlockElement) WithConfirm(confirm *ConfirmationDialogObject) *ExternalSelectBlockElement {
+	e.Confirm = confirm
+	return e
+}
+
+func NewExternalSelectBlockElement(placeholder *TextCompositionObject, actionID ActionID) *ExternalSelectBlockElement {
+	return &ExternalSelectBlockElement{
+		blockElement: blockElement{
+			Type: "external_select",
+		},
+		Placeholder: placeholder,
+		ActionID:    actionID,
+	}
+}
+
 // UsersSelectBlockElement is a Select menu element with a static list of Slack users visible to the current user.
 // This has a type of "users_select."
 type UsersSelectBlockElement struct {
@@ -242,6 +588,26 @@ type UsersSelectBlockElement struct {
 	ActionID      ActionID                  `json:"action_id"`
 	InitialUserID UserID                    `json:"users,omitempty"`
 	Confirm       *ConfirmationDialogObject `json:"confirm,omitempty"`
+}
+
+func (u *UsersSelectBlockElement) WithInitialUserID(userID UserID) *UsersSelectBlockElement {
+	u.InitialUserID = userID
+	return u
+}
+
+func (u *UsersSelectBlockElement) WithConfirm(confirm *ConfirmationDialogObject) *UsersSelectBlockElement {
+	u.Confirm = confirm
+	return u
+}
+
+func NewUsersSelectBlockElement(placeholder *TextCompositionObject, actionID ActionID) *UsersSelectBlockElement {
+	return &UsersSelectBlockElement{
+		blockElement: blockElement{
+			Type: "users_select",
+		},
+		Placeholder: placeholder,
+		ActionID:    actionID,
+	}
 }
 
 // ConversationsSelectBlockElement is a Select menu element with a list of public and private channels, DMs and MPIMs visible to the current user.
@@ -257,6 +623,41 @@ type ConversationsSelectBlockElement struct {
 	Filter                       *FilterObject             `json:"filter,omitempty"`
 }
 
+func (c *ConversationsSelectBlockElement) WithInitialConversation(initialConversation string) *ConversationsSelectBlockElement {
+	c.InitialConversation = initialConversation
+	return c
+}
+
+func (c *ConversationsSelectBlockElement) WithDefaultToCurrentConversation(flg bool) *ConversationsSelectBlockElement {
+	c.DefaultToCurrentConversation = flg
+	return c
+}
+
+func (c *ConversationsSelectBlockElement) WithConfirm(confirm *ConfirmationDialogObject) *ConversationsSelectBlockElement {
+	c.Confirm = confirm
+	return c
+}
+
+func (c *ConversationsSelectBlockElement) WithResponseURLEnabled(flg bool) *ConversationsSelectBlockElement {
+	c.ResponseURLEnabled = flg
+	return c
+}
+
+func (c *ConversationsSelectBlockElement) WithFilter(filter *FilterObject) *ConversationsSelectBlockElement {
+	c.Filter = filter
+	return c
+}
+
+func NewConversationsSelectBlockElement(placeholder *TextCompositionObject, actionID ActionID) *ConversationsSelectBlockElement {
+	return &ConversationsSelectBlockElement{
+		blockElement: blockElement{
+			Type: "conversations_select",
+		},
+		Placeholder: placeholder,
+		ActionID:    actionID,
+	}
+}
+
 // ChannelsSelectBlockElement is a Select menu element with a list of public channels visible to the current user.
 // This has a type of "conversations_select."
 type ChannelsSelectBlockElement struct {
@@ -268,11 +669,64 @@ type ChannelsSelectBlockElement struct {
 	ResponseURLEnabled bool                      `json:"response_url_enabled,omitempty"`
 }
 
+func (c *ChannelsSelectBlockElement) WithInitialChannelID(channelID ChannelID) *ChannelsSelectBlockElement {
+	c.InitialChannelID = channelID
+	return c
+}
+
+func (c *ChannelsSelectBlockElement) WithConfirm(confirm *ConfirmationDialogObject) *ChannelsSelectBlockElement {
+	c.Confirm = confirm
+	return c
+}
+
+func (c *ChannelsSelectBlockElement) WithResponseURLEnabled(flg bool) *ChannelsSelectBlockElement {
+	c.ResponseURLEnabled = flg
+	return c
+}
+
+func NewChannelsSelectBlockElement(placeholder *TextCompositionObject, actionID ActionID) *ChannelsSelectBlockElement {
+	return &ChannelsSelectBlockElement{
+		blockElement: blockElement{
+			Type: "channels_select",
+		},
+		Placeholder: placeholder,
+		ActionID:    actionID,
+	}
+}
+
 // TextObjectBlockElement has equal fields as TextCompositionObject does.
 // ContextBlock's Elements can include BlockElement and TextCompositionObject so this is a compromise to let []BlockElement include TextCompositionObject.
 type TextObjectBlockElement struct {
 	blockElement
 	Text     string `json:"text"`
 	Emoji    bool   `json:"emoji,omitempty"`
-	Verbatim bool   `json:"verbatim, omitempty"`
+	Verbatim bool   `json:"verbatim,omitempty"`
+}
+
+func (t *TextObjectBlockElement) WithEmoji(flg bool) *TextObjectBlockElement {
+	t.Emoji = flg
+	return t
+}
+
+func (t *TextObjectBlockElement) WithVerbatim(flg bool) *TextObjectBlockElement {
+	t.Verbatim = flg
+	return t
+}
+
+func NewPlainTextObjectBlockElement(text string) *TextObjectBlockElement {
+	return &TextObjectBlockElement{
+		blockElement: blockElement{
+			Type: "plain_text",
+		},
+		Text: text,
+	}
+}
+
+func NewMarkdownTextObjectBlockElement(text string) *TextObjectBlockElement {
+	return &TextObjectBlockElement{
+		blockElement: blockElement{
+			Type: "mrkdwn",
+		},
+		Text: text,
+	}
 }

--- a/event/block_element.go
+++ b/event/block_element.go
@@ -223,7 +223,7 @@ type MultiStaticSelectBlockElement struct {
 	MaxSelectedItems int                       `json:"max_selected_items,omitempty"`
 }
 
-func (m *MultiStaticSelectBlockElement) WithOptionsGroups(optionGroups []*OptionGroupObject) *MultiStaticSelectBlockElement {
+func (m *MultiStaticSelectBlockElement) WithOptionGroups(optionGroups []*OptionGroupObject) *MultiStaticSelectBlockElement {
 	m.OptionGroups = optionGroups
 	return m
 }

--- a/event/block_element.go
+++ b/event/block_element.go
@@ -100,7 +100,7 @@ type ButtonBlockElement struct {
 	ActionID ActionID                  `json:"action_id"`
 	URL      string                    `json:"url,omitempty"`
 	Value    string                    `json:"value,omitempty"`
-	Style    string                    `json:"style,omitempty"` // TODO "primary", "danger" or empty
+	Style    Style                     `json:"style,omitempty"`
 	Confirm  *ConfirmationDialogObject `json:"confirm,omitempty"`
 }
 

--- a/event/composition_object.go
+++ b/event/composition_object.go
@@ -18,7 +18,33 @@ type TextCompositionObject struct {
 	Type     string `json:"type"`
 	Text     string `json:"text"`
 	Emoji    bool   `json:"emoji,omitempty"`
-	Verbatim bool   `json:"verbatim, omitempty"`
+	Verbatim bool   `json:"verbatim,omitempty"`
+}
+
+func (tc *TextCompositionObject) WithEmoji(flg bool) *TextCompositionObject {
+	tc.Emoji = flg
+	return tc
+}
+
+func (tc *TextCompositionObject) WithVerbatim(flg bool) *TextCompositionObject {
+	tc.Verbatim = flg
+	return tc
+}
+
+func NewPlainTextCompositionObject(text string) *TextCompositionObject {
+	return &TextCompositionObject{
+		Type:     "plain_text",
+		Text:     text,
+		Emoji:    false,
+		Verbatim: false,
+	}
+}
+
+func NewMarkdownTextCompositionObject(text string) *TextCompositionObject {
+	return &TextCompositionObject{
+		Type: "mrkdwn",
+		Text: text,
+	}
 }
 
 type ConfirmationDialogObject struct {
@@ -27,15 +53,46 @@ type ConfirmationDialogObject struct {
 	Text    *TextCompositionObject `json:"text"`
 	Confirm *TextCompositionObject `json:"confirm"`
 	Deny    *TextCompositionObject `json:"deny"`
-	Style   string                 `json:"style,omitempty"`
+	Style   Style                  `json:"style,omitempty"`
+}
+
+func (cd *ConfirmationDialogObject) WithStyle(style Style) *ConfirmationDialogObject {
+	cd.Style = style
+	return cd
+}
+
+func NewConfirmationDialogObject(title, text, confirm, deny *TextCompositionObject) *ConfirmationDialogObject {
+	return &ConfirmationDialogObject{
+		Title:   title,
+		Text:    text,
+		Confirm: confirm,
+		Deny:    deny,
+	}
 }
 
 type OptionObject struct {
 	compositionObject
 	Text        *TextCompositionObject `json:"text"`
 	Value       string                 `json:"value"`
-	Description *TextCompositionObject `json:"description"`
+	Description *TextCompositionObject `json:"description,omitempty"`
 	URL         string                 `json:"url,omitempty"`
+}
+
+func (o *OptionObject) WithDescription(description *TextCompositionObject) *OptionObject {
+	o.Description = description
+	return o
+}
+
+func (o *OptionObject) WithURL(url string) *OptionObject {
+	o.URL = url
+	return o
+}
+
+func NewOptionObject(text *TextCompositionObject, value string) *OptionObject {
+	return &OptionObject{
+		Text:  text,
+		Value: value,
+	}
 }
 
 type OptionGroupObject struct {
@@ -44,9 +101,39 @@ type OptionGroupObject struct {
 	Options []CompositionObject    `json:"options"`
 }
 
+func NewOptionGroupObject(label *TextCompositionObject, options []CompositionObject) *OptionGroupObject {
+	return &OptionGroupObject{
+		Label:   label,
+		Options: options,
+	}
+}
+
 type FilterObject struct {
 	compositionObject
-	Include                       []string `json:"include,omitempty"` // im, mpim, private or public
-	ExcludeExternalSharedChannels bool     `json:"exclude_external_shared_channels,omitempty"`
-	ExcludeBotUsers               bool     `json:"exclude_bot_users"`
+	Include                       []ConversationType `json:"include,omitempty"`
+	ExcludeExternalSharedChannels bool               `json:"exclude_external_shared_channels,omitempty"`
+	ExcludeBotUsers               bool               `json:"exclude_bot_users,omitempty"`
+}
+
+func (f *FilterObject) WithInclude(conversationTypes []ConversationType) *FilterObject {
+	f.Include = conversationTypes
+	return f
+}
+
+func (f *FilterObject) WithExcludeExternalSharedChannels(flg bool) *FilterObject {
+	f.ExcludeExternalSharedChannels = flg
+	return f
+}
+
+func (f *FilterObject) WithExcludeBotUsers(flg bool) *FilterObject {
+	f.ExcludeBotUsers = flg
+	return f
+}
+
+func NewFilterObject() *FilterObject {
+	return &FilterObject{
+		Include:                       nil,
+		ExcludeExternalSharedChannels: false,
+		ExcludeBotUsers:               false,
+	}
 }

--- a/event/conversation.go
+++ b/event/conversation.go
@@ -1,0 +1,10 @@
+package event
+
+type ConversationType string
+
+const (
+	ConversationTypeIM           ConversationType = "im"
+	ConversationTypeMultiPartyIM ConversationType = "mpim"
+	ConversationTypePrivate      ConversationType = "private"
+	ConversationTypePublic       ConversationType = "public"
+)

--- a/event/style.go
+++ b/event/style.go
@@ -1,0 +1,8 @@
+package event
+
+type Style string
+
+const (
+	StylePrimary Style = "primary"
+	StyleDanger  Style = "danger"
+)

--- a/example/eventsapi/main.go
+++ b/example/eventsapi/main.go
@@ -22,8 +22,12 @@ type Receiver struct {
 
 func (r *Receiver) Receive(wrapper *eventsapi.EventWrapper) {
 	switch typed := wrapper.Event.(type) {
+	case *event.MessageChannels:
+		// A message in a public channel
+		log.Printf("Channel Message: %s", typed.Text)
+
 	case *event.MessageGroups:
-		// A message usually sent in a group
+		// A message in a private group
 		log.Printf("Group Message: %s", typed.Text)
 
 	case *event.MessageIM:

--- a/example/golack/eventsapi/main.go
+++ b/example/golack/eventsapi/main.go
@@ -52,8 +52,20 @@ func (r *Receiver) Receive(wrapper *eventsapi.EventWrapper) {
 			return
 		}
 
-		message := webapi.NewPostMessage(typed.ChannelID, echoMsg)
-		message.AsUser = true
+		message := webapi.NewPostMessage(typed.ChannelID, echoMsg).
+			WithBlocks([]event.Block{
+				event.NewSectionBlock(event.NewMarkdownTextCompositionObject("Below message was sent by the user as *.echo* command")),
+				event.NewDividerBlock(),
+				event.NewSectionBlock(event.NewPlainTextCompositionObject(echoMsg)).
+					WithFields([]*event.TextCompositionObject{
+						event.NewPlainTextCompositionObject("User ID"),
+						event.NewPlainTextCompositionObject(string(typed.UserID)),
+						event.NewPlainTextCompositionObject("Channel ID"),
+						event.NewPlainTextCompositionObject(string(typed.ChannelID)),
+						event.NewPlainTextCompositionObject("Time"),
+						event.NewPlainTextCompositionObject(typed.EventTimeStamp.Time.String()),
+					}),
+			})
 		log.Printf("Payload: %+v", message)
 		response, err := r.client.PostMessage(context.TODO(), message)
 		if err != nil {

--- a/example/golack/eventsapi/main.go
+++ b/example/golack/eventsapi/main.go
@@ -54,6 +54,11 @@ func (r *Receiver) Receive(wrapper *eventsapi.EventWrapper) {
 
 		message := webapi.NewPostMessage(typed.ChannelID, echoMsg).
 			WithBlocks([]event.Block{
+				event.NewContextBlock([]event.BlockElement{
+					event.NewPlainTextObjectBlockElement("Hello! Wanna grab a *beer*? :beer:").
+						WithEmoji(true),
+				}),
+				event.NewDividerBlock(),
 				event.NewSectionBlock(event.NewMarkdownTextCompositionObject("Below message was sent by the user as *.echo* command")),
 				event.NewDividerBlock(),
 				event.NewSectionBlock(event.NewPlainTextCompositionObject(echoMsg)).
@@ -66,7 +71,8 @@ func (r *Receiver) Receive(wrapper *eventsapi.EventWrapper) {
 						event.NewPlainTextCompositionObject(typed.EventTimeStamp.Time.String()),
 					}),
 			})
-		log.Printf("Payload: %+v", message)
+
+		log.Printf("Payload: %+v\n", message)
 		response, err := r.client.PostMessage(context.TODO(), message)
 		if err != nil {
 			log.Printf("Post error: %s", err.Error())

--- a/webapi/request.go
+++ b/webapi/request.go
@@ -44,17 +44,26 @@ type MessageAttachment struct {
 type PostMessage struct {
 	ChannelID       event.ChannelID      `json:"channel"`
 	Text            string               `json:"text"`
-	Parse           ParseMode            `json:"parse,omitempty"`
-	LinkNames       int                  `json:"link_names,omitempty"`
+	AsUser          bool                 `json:"as_user,omitempty"`
 	Attachments     []*MessageAttachment `json:"attachments,omitempty"`
+	Blocks          []event.Block        `json:"blocks,omitempty"`
+	IconEmoji       string               `json:"icon_emoji,omitempty"`
+	IconURL         string               `json:"icon_url,omitempty"`
+	LinkNames       int                  `json:"link_names,omitempty"`
+	Markdown        bool                 `json:"mrkdwn,omitempty"`
+	Parse           ParseMode            `json:"parse,omitempty"`
+	ReplyBroadcast  bool                 `json:"reply_broadcast,omitempty"`
+	ThreadTimeStamp string               `json:"thread_ts,omitempty"`
 	UnfurlLinks     bool                 `json:"unfurl_links,omitempty"`
 	UnfurlMedia     bool                 `json:"unfurl_media,omitempty"`
 	UserName        string               `json:"username,omitempty"`
-	AsUser          bool                 `json:"as_user,omitempty"`
-	IconURL         string               `json:"icon_url,omitempty"`
-	IconEmoji       string               `json:"icon_emoji,omitempty"`
-	ReplyBroadcast  bool                 `json:"reply_broadcast,omitempty"`
-	ThreadTimeStamp string               `json:"thread_ts,omitempty"`
+}
+
+// WithAsUser sets optional boolean value so the outgoing message is sent as a user.
+// See https://api.slack.com/methods/chat.postMessage
+func (message *PostMessage) WithAsUser(flg bool) *PostMessage {
+	message.AsUser = flg
+	return message
 }
 
 // WithAttachments sets/overrides attachments parameter for current PostMessage.
@@ -64,10 +73,38 @@ func (message *PostMessage) WithAttachments(attachments []*MessageAttachment) *P
 	return message
 }
 
+// WithBlocks sets/overrides blocks parameter for current PostMessage.
+// See https://api.slack.com/messaging/composing/layouts#adding-blocks
+func (message *PostMessage) WithBlocks(blocks []event.Block) *PostMessage {
+	message.Blocks = blocks
+	return message
+}
+
+// WithIconEmoji sets an icon emoji for the message.
+// See https://api.slack.com/methods/chat.postMessage
+func (message *PostMessage) WithIconEmoji(iconEmoji string) *PostMessage {
+	message.IconEmoji = iconEmoji
+	return message
+}
+
+// WithIconURL sets an icon image url for the message.
+// See https://api.slack.com/methods/chat.postMessage
+func (message *PostMessage) WithIconURL(iconURL string) *PostMessage {
+	message.IconURL = iconURL
+	return message
+}
+
 // WithLinkNames sets/overrides link_names parameter for current PostMessage.
 // See https://api.slack.com/methods/chat.postMessage#formatting
 func (message *PostMessage) WithLinkNames(linkNames int) *PostMessage {
 	message.LinkNames = linkNames
+	return message
+}
+
+// WithMarkdown sets optional boolean value to decide if the message should be treated as Markdown.
+// See https://api.slack.com/methods/chat.postMessage
+func (message *PostMessage) WithMarkdown(flg bool) *PostMessage {
+	message.Markdown = flg
 	return message
 }
 
@@ -81,8 +118,8 @@ func (message *PostMessage) WithParse(parse ParseMode) *PostMessage {
 // WithReplyBroadcast sets optional boolean value so the thread response can be broadcasted.
 // Thread identifier must be present with WithThreadTimeStamp() to use this option.
 // See https://api.slack.com/docs/message-threading#using_the_web_api
-func (message *PostMessage) WithReplyBroadcast(broadcast bool) *PostMessage {
-	message.ReplyBroadcast = broadcast
+func (message *PostMessage) WithReplyBroadcast(flg bool) *PostMessage {
+	message.ReplyBroadcast = flg
 	return message
 }
 
@@ -104,6 +141,13 @@ func (message *PostMessage) WithUnfurlLinks(unfurl bool) *PostMessage {
 // See https://api.slack.com/docs/message-attachments#unfurling
 func (message *PostMessage) WithUnfurlMedia(unfurl bool) *PostMessage {
 	message.UnfurlMedia = unfurl
+	return message
+}
+
+// WithUserName sets a name to be used as user name.
+// See https://api.slack.com/methods/chat.postMessage
+func (message *PostMessage) WithUserName(name string) *PostMessage {
+	message.UserName = name
 	return message
 }
 


### PR DESCRIPTION
This allows sending [messages with block layout](https://api.slack.com/messaging/composing/layouts#adding-blocks).